### PR TITLE
syscall-linux.c: don't include <sys/io.h>

### DIFF
--- a/src/linux/syscall-linux.c
+++ b/src/linux/syscall-linux.c
@@ -45,7 +45,6 @@
 #include <linux/posix_types.h>
 #include <linux/personality.h>
 #include <linux/sockios.h>
-#include <sys/io.h>
 
 #include <sys/file.h>
 #include <sys/fsuid.h>


### PR DESCRIPTION
Seems the <sys/io.h> header isn't used for anything, but it breaks build on platforms, where it is not available.