### PR TITLE
Fix most compiler warnings during build

### DIFF
--- a/src/ia_decoder.h
+++ b/src/ia_decoder.h
@@ -27,5 +27,6 @@
 EaInfoPtr ea16Info(ModRM modrm);
 EaInfoPtr ea32Info(ModRM modrm);
 BOOL ia_decode(ADDR4 eip, IAinstInfoPtr info);
+BOOL iadas_decode(ADDR4 eip, IAinstInfoPtr info);
 
 #endif	/* _SKI_IA_DECODER_H */

--- a/src/ia_decoder.tmpl.c
+++ b/src/ia_decoder.tmpl.c
@@ -29,6 +29,7 @@
 #include "types.h"
 #include "fields.h"
 #include "sim.h"
+#include "ia_decoder.h"
 #include "ia_exec.h"
 #include "sign_ext.h"
 

--- a/src/linux/syscall-linux.c
+++ b/src/linux/syscall-linux.c
@@ -1165,7 +1165,7 @@ mapSelectFds (BYTE *buf, int num, int *new_num)
 
   FD_ZERO (&fds);
   for (i = 0; i < num; i++)
-    if (FD_ISSET (i, (fd_set *)buf))
+    if (FD_ISSET (i, (fd_set *) buf))
       {
 	mapped_fd = fdmap[i];
 	backmap[mapped_fd] = i;
@@ -1673,8 +1673,8 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
 
     case SYS_OPEN:
     case LIA64_open:
-      simroot(ADDPTR(arg0), buf, arg1 & O_CREAT);
-      *status = open ((char *)buf, arg1, arg2);
+      simroot(ADDPTR(arg0), (char *) buf, arg1 & O_CREAT);
+      *status = open ((char *) buf, arg1, arg2);
       if ((int)*status != -1) {
 #ifdef HOST_MAP
 	int simfd;
@@ -1695,8 +1695,8 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
       break;
 
     case LIA64_openat:
-      simroot(ADDPTR(arg1), buf, arg2 & O_CREAT);
-      *status = openat (arg0, (char *)buf, arg2, arg3);
+      simroot(ADDPTR(arg1), (char *) buf, arg2 & O_CREAT);
+      *status = openat (arg0, (char *) buf, arg2, arg3);
       if ((int)*status != -1) {
 #ifdef HOST_MAP
 	int simfd;
@@ -1729,14 +1729,14 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
     case LIA64_link:
       memBBRd (ADDPTR (arg0), buf, 0);
       memBBRd (ADDPTR (arg1), buf2, 0);
-      *status = link ((char *)buf, (char *)buf2);
+      *status = link ((char *) buf, (char *) buf2);
       setStatReturn (ret, status);
       break;
 
     case SYS_UNLINK:
     case LIA64_unlink:
-      simroot(ADDPTR(arg0), buf, 0);
-      *status = unlink ((char *)buf);
+      simroot(ADDPTR(arg0), (char *) buf, 0);
+      *status = unlink ((char *) buf);
       setStatReturn (ret, status);
       break;
 
@@ -1766,7 +1766,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
 	      break;
 
 	    memBBRd (ADDPTR (argp), buf2, 0);
-	    len = strlen ((char*) buf2) + 1;
+	    len = strlen ((char *) buf2) + 1;
 	    if (off + len >= total)
 	      {
 		total += 32768;
@@ -1793,7 +1793,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
 	      break;
 
 	    memBBRd (argp, buf2, 0);
-	    len = strlen ((char *)buf2) + 1;
+	    len = strlen ((char *) buf2) + 1;
 	    if (off + len >= total)
 	      {
 		total += 32768;
@@ -1846,7 +1846,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
     case SYS_CHDIR:
     case LIA64_chdir:
       memBBRd (ADDPTR (arg0), buf, 0);
-      *status = chdir ((char *)buf);
+      *status = chdir ((char *) buf);
       setStatReturn (ret, status);
       break;
 
@@ -1872,21 +1872,21 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
     case SYS_MKNOD:
     case LIA64_mknod:
       memBBRd (ADDPTR (arg0), buf, 0);
-      *status = mknod ((char *)buf, arg1, arg2);
+      *status = mknod ((char *) buf, arg1, arg2);
       setStatReturn (ret, status);
       break;
 
     case SYS_CHMOD:
     case LIA64_chmod:
       memBBRd (ADDPTR (arg0), buf, 0);
-      *status = chmod ((char *)buf, arg1);
+      *status = chmod ((char *) buf, arg1);
       setStatReturn (ret, status);
       break;
 
     case SYS_CHOWN:
     case LIA64_chown:
       memBBRd (ADDPTR (arg0), buf, 0);
-      *status = chown ((char *)buf, arg1, arg2);
+      *status = chown ((char *) buf, arg1, arg2);
       setStatReturn (ret, status);
       break;
 
@@ -1917,14 +1917,14 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
       memBBRd (ADDPTR (arg0), buf, 0);
       memBBRd (ADDPTR (arg1), buf1, 0);
       memBBRd (ADDPTR (arg2), buf2, 0);
-      *status = mount ((char *)buf, (char *)buf1, (char *)buf2, arg3, 0);
+      *status = mount ((char *) buf, (char *) buf1, (char *) buf2, arg3, 0);
       setStatReturn (ret, status);
       break;
 
     case SYS_UMOUNT:
     case LIA64_umount:
       memBBRd (ADDPTR (arg0), buf, 0);
-      *status = umount ((char *)buf);
+      *status = umount ((char *) buf);
       setStatReturn (ret, status);
       break;
 
@@ -1952,14 +1952,14 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
 
     case SYS_ACCESS:
     case LIA64_access:
-      simroot(ADDPTR(arg0), buf, 0);
-      *status = access (buf, arg1);
+      simroot(ADDPTR(arg0), (char *) buf, 0);
+      *status = access ((char *) buf, arg1);
       setStatReturn (ret, status);
       break;
 
     case LIA64_faccessat:
-      simroot(ADDPTR(arg1), buf, 0);
-      *status = faccessat (fdmap[arg0], buf, arg2, arg3);
+      simroot(ADDPTR(arg1), (char *) buf, 0);
+      *status = faccessat (fdmap[arg0], (char *) buf, arg2, arg3);
       setStatReturn (ret, status);
       break;
 
@@ -1994,21 +1994,21 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
     case LIA64_rename:
       memBBRd (ADDPTR (arg0), buf, 0);
       memBBRd (ADDPTR (arg1), buf2, 0);
-      *status = rename ((char *)buf, (char *)buf2);
+      *status = rename ((char *) buf, (char *) buf2);
       setStatReturn (ret, status);
       break;
 
     case SYS_MKDIR:
     case LIA64_mkdir:
       memBBRd (ADDPTR (arg0), buf, 0);
-      *status = mkdir ((char *)buf, arg1);
+      *status = mkdir ((char *) buf, arg1);
       setStatReturn (ret, status);
       break;
 
     case SYS_RMDIR:
     case LIA64_rmdir:
       memBBRd (ADDPTR (arg0), buf, 0);
-      *status = rmdir ((char *)buf);
+      *status = rmdir ((char *) buf);
       setStatReturn (ret, status);
       break;
 
@@ -2752,7 +2752,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
 
     case SYS_READLINK:
     case LIA64_readlink:
-      simroot(ADDPTR(arg0), buf, 0);
+      simroot(ADDPTR(arg0), (char *) buf, 0);
       /* make sure we have enough space in malargbuf */
       ENSURE_SIZE (arg2);
       *status = readlink ((char *) buf, (char *) malargbuf, arg2);
@@ -2769,13 +2769,13 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
 
     case LIA64_swapon:
       memBBRd (ADDPTR (arg0), buf, 0);
-      *status = swapon ((char *)buf, arg1);
+      *status = swapon ((char *) buf, arg1);
       setStatReturn (ret, status);
       break;
 
     case LIA64_swapoff:
       memBBRd (ADDPTR (arg0), buf, 0);
-      *status = swapoff ((char *)buf);
+      *status = swapoff ((char *) buf);
       setStatReturn (ret, status);
       break;
 
@@ -2828,7 +2828,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
       if (num == LIA64_statfs)
 	{
 	  memBBRd (ADDPTR (arg0), buf, 0);
-	  *status = statfs ((char *)buf, &host_statfs);
+	  *status = statfs ((char *) buf, &host_statfs);
 	}
       else
 	{
@@ -3018,7 +3018,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
     case LIA64_syslog:
       if (arg2 > 0)
 	memBBRd (ADDPTR (arg1), buf, arg2);
-      *status = klogctl (arg0, (char *)buf, arg2);
+      *status = klogctl (arg0, (char *) buf, arg2);
       setStatReturn (ret, status);
       break;
 
@@ -3068,7 +3068,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
       break;
 
     case LIA64_old_stat:
-      simroot(ADDPTR(arg0), buf, 0);
+      simroot(ADDPTR(arg0), (char *) buf, 0);
       *status = stat ((char *) buf, &host_stat);
       if ((int) *status != -1)
 	{
@@ -3080,7 +3080,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
       break;
 
     case LIA64_stat:
-      simroot(ADDPTR(arg0), buf, 0);
+      simroot(ADDPTR(arg0), (char *) buf, 0);
       *status = stat ((char *) buf, &host_stat);
       if ((int) *status != -1)
 	{
@@ -3092,7 +3092,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
       break;
 
     case LIA64_old_lstat:
-      simroot(ADDPTR(arg0), buf, 0);
+      simroot(ADDPTR(arg0), (char *) buf, 0);
       *status = lstat ((char *) buf, &host_stat);
       if ((int) *status != -1)
 	{
@@ -3104,7 +3104,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
       break;
 
     case LIA64_lstat:
-      simroot(ADDPTR(arg0), buf, 0);
+      simroot(ADDPTR(arg0), (char *) buf, 0);
       *status = lstat ((char *) buf, &host_stat);
       if ((int) *status != -1)
 	{
@@ -3147,7 +3147,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
       */
       CHECK_FD (arg0);
       memBBRd (ADDPTR (arg1), buf, 0);
-      *status = fstatat (fdmap[arg0], buf, &host_stat, arg3);
+      *status = fstatat (fdmap[arg0], (const char *) buf, &host_stat, arg3);
       if ((int) *status != -1)
 	{
 	  stat_host2lia64 (&host_stat, &lia64_stat);
@@ -3164,7 +3164,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
 
     case LIA64_lchown:
       memBBRd (ADDPTR (arg0), buf, 0);
-      *status = lchown ((char *)buf, arg1, arg2);
+      *status = lchown ((char *) buf, arg1, arg2);
       setStatReturn (ret, status);
       break;
 
@@ -3224,7 +3224,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
     case LIA64_setdomainname:
       if (arg1 > 0)
 	memBBRd (ADDPTR (arg0), buf, arg1);
-      *status = setdomainname ((char *)buf, arg1);
+      *status = setdomainname ((char *) buf, arg1);
       setStatReturn (ret, status);
       break;
 
@@ -3232,11 +3232,11 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
       *status = uname ((struct utsname *) buf);
       if ((int) *status == 0)
 	{
-	  strcpy (&((struct utsname *)buf)->machine[0], "ia64");
+	  strcpy (&((struct utsname *) buf)->machine[0], "ia64");
 	  /* New glibc's check for minimum kernel. Defined in glibc as:
 	   * sysdeps/unix/sysv/linux/ia64/configure.ac:arch_minimum_kernel=3.2.18
 	   */
-	  strcpy (&((struct utsname *)buf)->release[0], "3.2.18");
+	  strcpy (&((struct utsname *) buf)->release[0], "3.2.18");
 	  memBBWrt_alloc (ADDPTR (arg0), buf, sizeof (struct utsname));
 	}
       setStatReturn (ret, status);
@@ -3837,7 +3837,7 @@ doSyscall (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG arg4,
 	      *status = -1; *ret = EINVAL;
 	      break;
 	    }
-	  if (status >= 0)
+	  if ((int)*status >= 0)
 	    masked_signals = lia64_sigset;
 	}
       break;
@@ -4571,7 +4571,7 @@ doSSC (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG *ret)
 	    for (;;) {
 		size_t r = fread(buffer, 1, sizeof (buffer), f);
 		if (r == 0) break;
-		memBBWrt(addr, buffer, r);
+		memBBWrt(addr, (const BYTE *) buffer, r);
 		addr += r;
 	    }
 	    fclose(f);
@@ -4589,11 +4589,11 @@ doSSC (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG *ret)
       memBBRd (arg0, buf, 0);
       PSR_DT = olddt;
       if (arg1 == SSC_READ_ACCESS)
-	*ret = open ((char *)buf, O_RDONLY);
+	*ret = open ((char *) buf, O_RDONLY);
       else if (arg1 == SSC_WRITE_ACCESS)
-	*ret = open ((char *)buf, O_WRONLY);
+	*ret = open ((char *) buf, O_WRONLY);
       else if (arg1 == (SSC_READ_ACCESS | SSC_WRITE_ACCESS))
-	*ret = open ((char *)buf, O_RDWR);
+	*ret = open ((char *) buf, O_RDWR);
       else
 	progExit ("doSSC (SSC_OPEN): arg1 has an illegal access type\n");
       break;
@@ -4796,7 +4796,7 @@ doSSC (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG *ret)
       PSR_DT = 0;
       memBBRd (arg1, buf, 0);
       /* arg0, arg2, and arg3 are currently not used */
-      if (elfSymLoad((char *)buf))
+      if (elfSymLoad((char *) buf))
 	*ret = 0;
       else
 	*ret = -1;
@@ -4855,7 +4855,7 @@ doSSC (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG *ret)
     case SSC_PUTCHAR:
       buf[0] = arg0;
       buf[1] = '\0';
-      writeConsole ((char *)buf, 1);
+      writeConsole ((char *) buf, 1);
       /* no return value */
       break;
 
@@ -4878,7 +4878,7 @@ doSSC (HWORD num, REG arg0, REG arg1, REG arg2, REG arg3, REG *ret)
 	memBBRd (arg0, buf, 0);
 
 	/* buf holds the device name to open on the host */
-        *ret = (long)netdev_open ((char *)buf, ether);
+        *ret = (long)netdev_open ((char *) buf, ether);
 
 	/* copy back the link level addr */
 	memBBWrt (arg1, (BYTE *)ether, sizeof (ether));

--- a/src/load.c
+++ b/src/load.c
@@ -990,7 +990,7 @@ static ADDR getNSgp(Elf *elfptr)
  *-------------------------------------------------------------------------*/
 BOOL elfLoad(const char *file_name, int s_argc, char *s_argv[])
 {
-    struct os_proc proc = {};
+    struct os_proc proc = {0};
     Elf *elfptr;
     int fd;
     unsigned char class;

--- a/src/os_support.c
+++ b/src/os_support.c
@@ -69,15 +69,15 @@ simroot(REG arg, char *path, int creat)
 	char c, *p;
 
 	p = path;
-	memBBRd(arg, &c, 1);
+	memBBRd(arg, (BYTE *) &c, 1);
 	if (c == '/') {
 		strcpy(p, sim_root);
 		p += sim_root_len;
 	}
-	memBBRd(arg, p, 0);
+	memBBRd(arg, (BYTE *) p, 0);
 	if (p == path)
 		return (0);
 	if (access(path, F_OK) != 0)
-		memBBRd(arg, path, 0);
+		memBBRd(arg, (BYTE *) path, 0);
 	return (0);
 }

--- a/src/platform.c
+++ b/src/platform.c
@@ -356,7 +356,7 @@ int ioLoad(IS_t *argIn)
 			offset, argIn->data, argIn->size);
 	}
 	unsigned char c = '\0';
-	uartRead(1, offset, &c);
+	uartRead(1, offset, (char *) &c);
 	argIn->data = c;
 	return 2;
     }
@@ -367,7 +367,7 @@ int ioLoad(IS_t *argIn)
 			offset, argIn->data, argIn->size);
 	}
 	unsigned char c = '\0';
-	uartRead(2, offset, &c);
+	uartRead(2, offset, (char *) &c);
 	argIn->data = c;
 	return 2;
     }

--- a/src/program.c
+++ b/src/program.c
@@ -278,6 +278,8 @@ xxx:
 }
 
 #undef EIPfromIP
+ADDR4 EIPfromIP(ADDR adr);
+
 ADDR4 EIPfromIP(ADDR adr)
 {
     REG tmpreg = grGet(viewPid, CSD_ID);

--- a/src/sim.c
+++ b/src/sim.c
@@ -398,6 +398,8 @@ static void fillinDecodePage(CT *ct, ADDR adr)
     }
 }
 
+Status iAinstFetchDecode(IAinstInfoPtr info);
+
 Status iAinstFetchDecode(IAinstInfoPtr info)
 {
     if (!ia_decode(EIP, info))

--- a/src/ssDSym.c
+++ b/src/ssDSym.c
@@ -226,10 +226,10 @@ static REG wrapper(int unused)        \
 }
 
 
-MK_ACCESSOR_01(getTotalCycles1, getTotalCycles);
-MK_ACCESSOR_01(getTotalInsts1, getTotalInsts);
-MK_ACCESSOR_01(getTotalFaults1, getTotalFaults);
-MK_ACCESSOR_01(getExited1, getExited);
+MK_ACCESSOR_01(getTotalCycles1, getTotalCycles)
+MK_ACCESSOR_01(getTotalInsts1, getTotalInsts)
+MK_ACCESSOR_01(getTotalFaults1, getTotalFaults)
+MK_ACCESSOR_01(getExited1, getExited)
 
 /*---------------------------------------------------------------------------
  * internalSymbol$Init - Initialize the internal symbol table.

--- a/src/syscall_api.h
+++ b/src/syscall_api.h
@@ -10,7 +10,7 @@
 
 #include "types.h"
 
-char *getSrcLines(ADDR ofs, unsigned *count);;
+char *getSrcLines(ADDR ofs, unsigned *count);
 
 void signal_invoke_handler (int in_syscall);
 int signal_pending(void);

--- a/src/tlb.c
+++ b/src/tlb.c
@@ -1300,7 +1300,10 @@ static TlbEntry *tcInsert(TlbEntry tc[], unsigned tccnt,
 {
     ADDR rangeMask = (~ONES(BitfX(tar,56,6)) & ~VRN_MASK) | 1;
     ADDR vam = tva & rangeMask;
-    unsigned i, ind, first_when, rid = RR_RID(RR(tva));
+    unsigned i, rid = RR_RID(RR(tva));
+#if 0
+    unsigned ind, first_when;
+#endif
     static unsigned when = 0;
     BOOL found = NO;
     TlbEntry *tce;


### PR DESCRIPTION
This patch set silences the following compiler warnings during build for me with GCC 11.5.0-1 and 14.2.0-12 on Debian Sid:

```diff
--- <a/master>
+++ <b/master-patched>
@@ -88,35 +88,8 @@
   CC       sim.o
   CC       simmem.o
   CC       float.o
-In file included from exec.incl.c:46,
-                 from combfns.gen.c:27:
-syscall_api.h:13:46: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-   13 | char *getSrcLines(ADDR ofs, unsigned *count);;
-      |                                              ^
-In file included from simmem.c:49:
-syscall_api.h:13:46: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-   13 | char *getSrcLines(ADDR ofs, unsigned *count);;
-      |                                              ^
-In file included from sim.c:66:
-syscall_api.h:13:46: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-   13 | char *getSrcLines(ADDR ofs, unsigned *count);;
-      |                                              ^
-sim.c:401:8: warning: no previous declaration for ‘iAinstFetchDecode’ [-Wmissing-declarations]
-  401 | Status iAinstFetchDecode(IAinstInfoPtr info)
-      |        ^~~~~~~~~~~~~~~~~
   CC       interruption.o
-In file included from interruption.c:36:
-syscall_api.h:13:46: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-   13 | char *getSrcLines(ADDR ofs, unsigned *count);;
-      |                                              ^
   CC       tlb.o
-tlb.c: In function ‘tcInsert’:
-tlb.c:1303:22: warning: unused variable ‘first_when’ [-Wunused-variable]
- 1303 |     unsigned i, ind, first_when, rid = RR_RID(RR(tva));
-      |                      ^~~~~~~~~~
-tlb.c:1303:17: warning: unused variable ‘ind’ [-Wunused-variable]
- 1303 |     unsigned i, ind, first_when, rid = RR_RID(RR(tva));
-      |                 ^~~
   CC       ia_read.o
   CC       ia_exec.o
   CC       ia_write.o
@@ -132,53 +105,12 @@
 	-v EXECTBL=execTbl \
 	./encodings/encoding.opcode \
 	unused=1 ./encodings/encoding.unusedop
-os_support.c: In function ‘simroot’:
-os_support.c:72:22: warning: pointer targets in passing argument 2 of ‘memBBRd’ differ in signedness [-Wpointer-sign]
-   72 |         memBBRd(arg, &c, 1);
-      |                      ^~
-      |                      |
-      |                      char *
-In file included from tlb.h:27,
-                 from state.h:25,
-                 from os_support.c:27:
-simmem.h:147:30: note: expected ‘BYTE *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
-  147 | BOOL memBBRd(ADDR adr, BYTE *buf, unsigned nbytes);
-      |                        ~~~~~~^~~
-os_support.c:77:22: warning: pointer targets in passing argument 2 of ‘memBBRd’ differ in signedness [-Wpointer-sign]
-   77 |         memBBRd(arg, p, 0);
-      |                      ^
-      |                      |
-      |                      char *
-simmem.h:147:30: note: expected ‘BYTE *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
-  147 | BOOL memBBRd(ADDR adr, BYTE *buf, unsigned nbytes);
-      |                        ~~~~~~^~~
-os_support.c:81:30: warning: pointer targets in passing argument 2 of ‘memBBRd’ differ in signedness [-Wpointer-sign]
-   81 |                 memBBRd(arg, path, 0);
-      |                              ^~~~
-      |                              |
-      |                              char *
-simmem.h:147:30: note: expected ‘BYTE *’ {aka ‘unsigned char *’} but argument is of type ‘char *’
-  147 | BOOL memBBRd(ADDR adr, BYTE *buf, unsigned nbytes);
-      |                        ~~~~~~^~~
   CC       netdev.o
   CC       libsym.o
   CC       asm_hash.gen.o
   CC       iadas_decoder.gen.o
   CC       das_instr.gen.o
-iadas_decoder.gen.c:178:11: warning: no previous declaration for ‘ea16Info’ [-Wmissing-declarations]
-  178 | EaInfoPtr ea16Info(ModRM modrm)
-      |           ^~~~~~~~
-iadas_decoder.gen.c:185:11: warning: no previous declaration for ‘ea32Info’ [-Wmissing-declarations]
-  185 | EaInfoPtr ea32Info(ModRM modrm)
-      |           ^~~~~~~~
-iadas_decoder.gen.c:4549:6: warning: no previous declaration for ‘iadas_decode’ [-Wmissing-declarations]
- 4549 | BOOL iadas_decode(ADDR4 eip, IAinstInfoPtr info)
-      |      ^~~~~~~~~~~~
   CC       ski.o
-In file included from ski.c:44:
-syscall_api.h:13:46: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-   13 | char *getSrcLines(ADDR ofs, unsigned *count);;
-      |                                              ^
   CC       menu.o
   CC       ssDBT.o
   CC       ssDDM.o
@@ -188,218 +120,30 @@
   CC       ssDSym.o
   CC       ssDPrs.o
   CC       traceui.o
-In file included from program.c:48:
-syscall_api.h:13:46: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-   13 | char *getSrcLines(ADDR ofs, unsigned *count);;
-      |                                              ^
-program.c:281:7: warning: no previous declaration for ‘EIPfromIP’ [-Wmissing-declarations]
-  281 | ADDR4 EIPfromIP(ADDR adr)
-      |       ^~~~~~~~~
-ssDSym.c:229:48: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-  229 | MK_ACCESSOR_01(getTotalCycles1, getTotalCycles);
-      |                                                ^
-ssDSym.c:230:46: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-  230 | MK_ACCESSOR_01(getTotalInsts1, getTotalInsts);
-      |                                              ^
-ssDSym.c:231:48: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-  231 | MK_ACCESSOR_01(getTotalFaults1, getTotalFaults);
-      |                                                ^
-ssDSym.c:232:38: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-  232 | MK_ACCESSOR_01(getExited1, getExited);
-      |                                      ^
   CC       ia_das.o
   CC       ui.o
   CC       batch.o
   CC       cur.o
   CC       firmware.o
   CC       asm.o
-In file included from cur.c:46:
-syscall_api.h:13:46: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-   13 | char *getSrcLines(ADDR ofs, unsigned *count);;
-      |                                              ^
   CC       escan.gen.o
   CC       eparse.gen.o
   CC       load.o
   CC       pci.o
   CC       platform.o
   CC       libdas.o
-In file included from load.c:59:
-syscall_api.h:13:46: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-   13 | char *getSrcLines(ADDR ofs, unsigned *count);;
-      |                                              ^
-load.c: In function ‘elfLoad’:
-load.c:993:27: warning: ISO C forbids empty initializer braces before C23 [-Wpedantic]
-  993 |     struct os_proc proc = {};
-      |                           ^
-In file included from platform.c:36:
-syscall_api.h:13:46: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-   13 | char *getSrcLines(ADDR ofs, unsigned *count);;
-      |                                              ^
-platform.c: In function ‘ioLoad’:
-platform.c:359:29: warning: pointer targets in passing argument 3 of ‘uartRead’ differ in signedness [-Wpointer-sign]
-  359 |         uartRead(1, offset, &c);
-      |                             ^~
-      |                             |
-      |                             unsigned char *
-platform.c:264:52: note: expected ‘char *’ but argument is of type ‘unsigned char *’
-  264 | static void uartRead(int uartno, int regno, char * pc) {
-      |                                             ~~~~~~~^~
-platform.c:370:29: warning: pointer targets in passing argument 3 of ‘uartRead’ differ in signedness [-Wpointer-sign]
-  370 |         uartRead(2, offset, &c);
-      |                             ^~
-      |                             |
-      |                             unsigned char *
-platform.c:264:52: note: expected ‘char *’ but argument is of type ‘unsigned char *’
-  264 | static void uartRead(int uartno, int regno, char * pc) {
-      |                                             ~~~~~~~^~
   CC       libsrs.o
   CC       instr.gen.o
   CC       linux/dwarf-linux.o
   CC       linux/osload-linux.o
   CC       linux/syscall-linux.o
   CC       linux/syscall-print.o
-In file included from linux/dwarf-linux.c:36:
-./syscall_api.h:13:46: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-   13 | char *getSrcLines(ADDR ofs, unsigned *count);;
-      |                                              ^
   CC       decoder/decoder.o
   CC       decoder/parts.o
   CC       decoder/decode_tree.gen.o
   CC       encoder/encoder.o
   CC       encoder/encode_table.gen.o
   CC       encoder/formats.gen.o
-In file included from linux/syscall-linux.c:96:
-./syscall_api.h:13:46: warning: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
-   13 | char *getSrcLines(ADDR ofs, unsigned *count);;
-      |                                              ^
-linux/syscall-linux.c: In function ‘doSyscall’:
-linux/syscall-linux.c:1676:29: warning: pointer targets in passing argument 2 of ‘simroot’ differ in signedness [-Wpointer-sign]
- 1676 |       simroot(ADDPTR(arg0), buf, arg1 & O_CREAT);
-      |                             ^~~
-      |                             |
-      |                             BYTE * {aka unsigned char *}
-In file included from linux/syscall-linux.c:95:
-./os_support.h:35:28: note: expected ‘char *’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-   35 | int simroot(REG arg, char *path, int creat);
-      |                      ~~~~~~^~~~
-linux/syscall-linux.c:1698:29: warning: pointer targets in passing argument 2 of ‘simroot’ differ in signedness [-Wpointer-sign]
- 1698 |       simroot(ADDPTR(arg1), buf, arg2 & O_CREAT);
-      |                             ^~~
-      |                             |
-      |                             BYTE * {aka unsigned char *}
-./os_support.h:35:28: note: expected ‘char *’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-   35 | int simroot(REG arg, char *path, int creat);
-      |                      ~~~~~~^~~~
-linux/syscall-linux.c:1738:29: warning: pointer targets in passing argument 2 of ‘simroot’ differ in signedness [-Wpointer-sign]
- 1738 |       simroot(ADDPTR(arg0), buf, 0);
-      |                             ^~~
-      |                             |
-      |                             BYTE * {aka unsigned char *}
-./os_support.h:35:28: note: expected ‘char *’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-   35 | int simroot(REG arg, char *path, int creat);
-      |                      ~~~~~~^~~~
-linux/syscall-linux.c:1955:29: warning: pointer targets in passing argument 2 of ‘simroot’ differ in signedness [-Wpointer-sign]
- 1955 |       simroot(ADDPTR(arg0), buf, 0);
-      |                             ^~~
-      |                             |
-      |                             BYTE * {aka unsigned char *}
-./os_support.h:35:28: note: expected ‘char *’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-   35 | int simroot(REG arg, char *path, int creat);
-      |                      ~~~~~~^~~~
-linux/syscall-linux.c:1956:25: warning: pointer targets in passing argument 1 of ‘access’ differ in signedness [-Wpointer-sign]
- 1956 |       *status = access (buf, arg1);
-      |                         ^~~
-      |                         |
-      |                         BYTE * {aka unsigned char *}
-In file included from /usr/include/x86_64-linux-gnu/bits/sigstksz.h:24,
-                 from /usr/include/signal.h:328,
-                 from linux/syscall-linux.c:30:
-/usr/include/unistd.h:287:32: note: expected ‘const char *’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-  287 | extern int access (const char *__name, int __type) __THROW __nonnull ((1));
-      |                    ~~~~~~~~~~~~^~~~~~
-linux/syscall-linux.c:1961:29: warning: pointer targets in passing argument 2 of ‘simroot’ differ in signedness [-Wpointer-sign]
- 1961 |       simroot(ADDPTR(arg1), buf, 0);
-      |                             ^~~
-      |                             |
-      |                             BYTE * {aka unsigned char *}
-./os_support.h:35:28: note: expected ‘char *’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-   35 | int simroot(REG arg, char *path, int creat);
-      |                      ~~~~~~^~~~
-linux/syscall-linux.c:1962:41: warning: pointer targets in passing argument 2 of ‘faccessat’ differ in signedness [-Wpointer-sign]
- 1962 |       *status = faccessat (fdmap[arg0], buf, arg2, arg3);
-      |                                         ^~~
-      |                                         |
-      |                                         BYTE * {aka unsigned char *}
-/usr/include/unistd.h:309:45: note: expected ‘const char *’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-  309 | extern int faccessat (int __fd, const char *__file, int __type, int __flag)
-      |                                 ~~~~~~~~~~~~^~~~~~
-linux/syscall-linux.c:2755:29: warning: pointer targets in passing argument 2 of ‘simroot’ differ in signedness [-Wpointer-sign]
- 2755 |       simroot(ADDPTR(arg0), buf, 0);
-      |                             ^~~
-      |                             |
-      |                             BYTE * {aka unsigned char *}
-./os_support.h:35:28: note: expected ‘char *’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-   35 | int simroot(REG arg, char *path, int creat);
-      |                      ~~~~~~^~~~
-linux/syscall-linux.c:3071:29: warning: pointer targets in passing argument 2 of ‘simroot’ differ in signedness [-Wpointer-sign]
- 3071 |       simroot(ADDPTR(arg0), buf, 0);
-      |                             ^~~
-      |                             |
-      |                             BYTE * {aka unsigned char *}
-./os_support.h:35:28: note: expected ‘char *’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-   35 | int simroot(REG arg, char *path, int creat);
-      |                      ~~~~~~^~~~
-linux/syscall-linux.c:3083:29: warning: pointer targets in passing argument 2 of ‘simroot’ differ in signedness [-Wpointer-sign]
- 3083 |       simroot(ADDPTR(arg0), buf, 0);
-      |                             ^~~
-      |                             |
-      |                             BYTE * {aka unsigned char *}
-./os_support.h:35:28: note: expected ‘char *’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-   35 | int simroot(REG arg, char *path, int creat);
-      |                      ~~~~~~^~~~
-linux/syscall-linux.c:3095:29: warning: pointer targets in passing argument 2 of ‘simroot’ differ in signedness [-Wpointer-sign]
- 3095 |       simroot(ADDPTR(arg0), buf, 0);
-      |                             ^~~
-      |                             |
-      |                             BYTE * {aka unsigned char *}
-./os_support.h:35:28: note: expected ‘char *’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-   35 | int simroot(REG arg, char *path, int creat);
-      |                      ~~~~~~^~~~
-linux/syscall-linux.c:3107:29: warning: pointer targets in passing argument 2 of ‘simroot’ differ in signedness [-Wpointer-sign]
- 3107 |       simroot(ADDPTR(arg0), buf, 0);
-      |                             ^~~
-      |                             |
-      |                             BYTE * {aka unsigned char *}
-./os_support.h:35:28: note: expected ‘char *’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-   35 | int simroot(REG arg, char *path, int creat);
-      |                      ~~~~~~^~~~
-linux/syscall-linux.c:3150:39: warning: pointer targets in passing argument 2 of ‘fstatat’ differ in signedness [-Wpointer-sign]
- 3150 |       *status = fstatat (fdmap[arg0], buf, &host_stat, arg3);
-      |                                       ^~~
-      |                                       |
-      |                                       BYTE * {aka unsigned char *}
-In file included from /usr/include/features.h:510,
-                 from /usr/include/errno.h:25,
-                 from linux/syscall-linux.c:25:
-/usr/include/x86_64-linux-gnu/sys/stat.h:279:12: note: expected ‘const char * restrict’ but argument is of type ‘BYTE *’ {aka ‘unsigned char *’}
-  279 | extern int __REDIRECT_NTH (fstatat, (int __fd, const char *__restrict __file,
-      |            ^~~~~~~~~~~~~~
-linux/syscall-linux.c:3840:22: warning: ordered comparison of pointer with integer zero [-Wpedantic]
- 3840 |           if (status >= 0)
-      |                      ^~
-linux/syscall-linux.c: In function ‘doSSC’:
-linux/syscall-linux.c:4574:32: warning: pointer targets in passing argument 2 of ‘memBBWrt’ differ in signedness [-Wpointer-sign]
- 4574 |                 memBBWrt(addr, buffer, r);
-      |                                ^~~~~~
-      |                                |
-      |                                char *
-In file included from ./tlb.h:27,
-                 from ./state.h:25,
-                 from ./exec.h:5,
-                 from linux/syscall-linux.c:79:
-./simmem.h:149:37: note: expected ‘const BYTE *’ {aka ‘const unsigned char *’} but argument is of type ‘char *’
-  149 | void memBBWrt(ADDR adr, const BYTE *buf, unsigned nbytes);
-      |                         ~~~~~~~~~~~~^~~
   CCLD     ski
 make[4]: Leaving directory '/usr/src/ski/src'
 make[3]: Leaving directory '/usr/src/ski/src'
```