### PR TITLE
ski-efi: A new binary for a minimal EFI binary

### DIFF
--- a/ski-efi/Makefile
+++ b/ski-efi/Makefile
@@ -1,0 +1,23 @@
+SKI_BOOTLOADER_OBJS = \
+	boot_head.o \
+	bootloader.o \
+	fw-emu.o \
+	memstr.o
+
+ski-efi: $(SKI_BOOTLOADER_OBJS) bootloader.lds
+	$(LD) $(SKI_BOOTLOADER_OBJS) -o $@ -static -T bootloader.lds
+
+CROSS_COMPILE = ia64-unknown-linux-gnu-
+CC = $(CROSS_COMPILE)gcc
+LD = $(CROSS_COMPILE)ld
+
+CFLAGS  = \
+	-nostdinc -Iinclude \
+	-ffixed-r13 -mfixed-range=f12-f15,f32-f127 -mconstant-gp -g \
+	-falign-functions=32 -frename-registers -fno-optimize-sibling-calls -fno-builtin
+
+ASFLAGS = \
+	-nostdinc -Iinclude \
+	\
+	-mconstant-gp \
+	-Wa,-gdwarf-2

--- a/ski-efi/README.md
+++ b/ski-efi/README.md
@@ -1,0 +1,40 @@
+`ski-efi` is a minimal EFI for Ski to load EFI binaries
+in PE32+ format.
+
+Currently kernel loading and console output relies on `Ski`-specifc
+"syscalls". Eventually it will switch to use standard emulated devices
+(like UART8250).
+
+# Current status
+
+`ski-efi` still relies on `Ski`-specific "syscalls" and can boot
+`GRUB` which in turn can load kernel up to `linux-4.19`.
+
+# Supported options
+
+`ski-efi` understands some of the parameters passed to `ski`:
+
+- first argument is interpreted as an EFI file name. `vmlinux` is
+  used if no parameters are present.
+
+# How to build
+
+The build requires you to have **ia64-unknown-linux-gnu** toolchain:
+**gcc** and **binutils**. Once you have it's it's just a matter of
+running 'make':
+
+    $ make
+
+Whis will build you a static IA64 firmware in `ski-efi` file.
+
+# How to run
+
+Once you got `ski-efi` you can run `Ski`:
+
+    $ grub-mkstandalone -o grub.efi -O ia64-efi
+    $ bski ./ski-efi grub.efi
+
+# Bit of history
+
+`ski-efi` was developped in order to test ia64 GRUB in a virtual
+environment.

--- a/ski-efi/boot_head.S
+++ b/ski-efi/boot_head.S
@@ -1,0 +1,163 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 1998-2003 Hewlett-Packard Co
+ *	David Mosberger-Tang <davidm@hpl.hp.com>
+ */
+
+#include <ia64/pal.h>
+
+#define ENTRY(name)		\
+	.align 32;		\
+	.proc name;		\
+name:
+
+#define GLOBAL_ENTRY(name)	\
+	.global name;		\
+	ENTRY(name)
+
+#define END(name)		\
+	.endp name
+
+	.bss
+	.align 16
+stack_mem:
+	.skip 16834
+
+	.text
+
+GLOBAL_ENTRY(_start)
+	.prologue
+	.save rp, r0
+	.body
+	movl gp = __gp
+	movl sp = stack_mem+16384-16
+	bsw.1
+	br.call.sptk.many rp=start_bootloader
+0:	nop 0		  /* dummy nop to make unwinding work */
+END(_start)
+
+GLOBAL_ENTRY(ssc)
+	.regstk 5,0,0,0
+	mov r15=in4
+	break 0x80001
+	br.ret.sptk.many b0
+END(ssc)
+
+GLOBAL_ENTRY(jmp_to_kernel)
+	.regstk 2,0,0,0
+	mov r28=in0
+	mov b7=in1
+	br.sptk.few b7
+END(jmp_to_kernel)
+
+/*
+ * r28 contains the index of the PAL function
+ * r29--31 the args
+ * Return values in ret0--3 (r8--11)
+ */
+GLOBAL_ENTRY(pal_emulator_static)
+	mov r8=-1
+	mov r9=256
+	;;
+	cmp.gtu p6,p7=r9,r28		/* r28 <= 255? */
+(p6)	br.cond.sptk.few static
+	;;
+	mov r9=512
+	;;
+	cmp.gtu p6,p7=r9,r28
+(p6)	br.cond.sptk.few stacked
+	;;
+static:	cmp.eq p6,p7=PAL_PTCE_INFO,r28
+(p7)	br.cond.sptk.few 1f
+	;;
+	mov r8=0			/* status = 0 */
+	movl r9=0x100000000		/* tc.base */
+	movl r10=0x0000000200000003	/* count[0], count[1] */
+	movl r11=0x1000000000002000	/* stride[0], stride[1] */
+	br.cond.sptk.few rp
+1:	cmp.eq p6,p7=PAL_FREQ_RATIOS,r28
+(p7)	br.cond.sptk.few 1f
+	mov r8=0			/* status = 0 */
+	movl r9 =0x100000064		/* proc_ratio (1/100) */
+	movl r10=0x100000100		/* bus_ratio<<32 (1/256) */
+	movl r11=0x100000064		/* itc_ratio<<32 (1/100) */
+	;;
+1:	cmp.eq p6,p7=PAL_RSE_INFO,r28
+(p7)	br.cond.sptk.few 1f
+	mov r8=0			/* status = 0 */
+	mov r9=96			/* num phys stacked */
+	mov r10=0			/* hints */
+	mov r11=0
+	br.cond.sptk.few rp
+1:	cmp.eq p6,p7=PAL_CACHE_FLUSH,r28		/* PAL_CACHE_FLUSH */
+(p7)	br.cond.sptk.few 1f
+	mov r9=ar.lc
+	movl r8=524288			/* flush 512k million cache lines (16MB) */
+	;;
+	mov ar.lc=r8
+	movl r8=0xe000000000000000
+	;;
+.loop:	fc r8
+	add r8=32,r8
+	br.cloop.sptk.few .loop
+	sync.i
+	;;
+	srlz.i
+	;;
+	mov ar.lc=r9
+	mov r8=r0
+	;;
+1:	cmp.eq p6,p7=PAL_PERF_MON_INFO,r28
+(p7)	br.cond.sptk.few 1f
+	mov r8=0			/* status = 0 */
+	movl r9 =0x08122f04		/* generic=4 width=47 retired=8 cycles=18 */
+	mov r10=0			/* reserved */
+	mov r11=0			/* reserved */
+	mov r16=0xffff			/* implemented PMC */
+	mov r17=0x3ffff			/* implemented PMD */
+	add r18=8,r29			/* second index */
+	;;
+	st8 [r29]=r16,16		/* store implemented PMC */
+	st8 [r18]=r0,16			/* clear remaining bits  */
+	;;
+	st8 [r29]=r0,16			/* clear remaining bits  */
+	st8 [r18]=r0,16			/* clear remaining bits  */
+	;;
+	st8 [r29]=r17,16		/* store implemented PMD */
+	st8 [r18]=r0,16			/* clear remaining bits  */
+	mov r16=0xf0			/* cycles count capable PMC */
+	;;
+	st8 [r29]=r0,16			/* clear remaining bits  */
+	st8 [r18]=r0,16			/* clear remaining bits  */
+	mov r17=0xf0			/* retired bundles capable PMC */
+	;;
+	st8 [r29]=r16,16		/* store cycles capable */
+	st8 [r18]=r0,16			/* clear remaining bits  */
+	;;
+	st8 [r29]=r0,16			/* clear remaining bits  */
+	st8 [r18]=r0,16			/* clear remaining bits  */
+	;;
+	st8 [r29]=r17,16		/* store retired bundle capable */
+	st8 [r18]=r0,16			/* clear remaining bits  */
+	;;
+	st8 [r29]=r0,16			/* clear remaining bits  */
+	st8 [r18]=r0,16			/* clear remaining bits  */
+	;;
+1:	cmp.eq p6,p7=PAL_VM_SUMMARY,r28
+(p7)	br.cond.sptk.few 1f
+	mov	r8=0			/* status = 0  */
+	movl	r9=0x2044040020F1865	/* num_tc_levels=2, num_unique_tcs=4 */
+					/* max_itr_entry=64, max_dtr_entry=64 */
+					/* hash_tag_id=2, max_pkr=15 */
+					/* key_size=24, phys_add_size=50, vw=1 */
+	movl	r10=0x183C		/* rid_size=24, impl_va_msb=60 */
+	;;
+1:	cmp.eq p6,p7=PAL_MEM_ATTRIB,r28
+(p7)	br.cond.sptk.few 1f
+	mov	r8=0			/* status = 0 */
+	mov	r9=0x80|0x01		/* NatPage|WB */
+	;;
+1:	br.cond.sptk.few rp
+stacked:
+	br.ret.sptk.few rp
+END(pal_emulator_static)

--- a/ski-efi/bootloader.c
+++ b/ski-efi/bootloader.c
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * arch/ia64/hp/sim/boot/bootloader.c
+ *
+ * Loads an ELF kernel.
+ *
+ * Copyright (C) 1998-2003 Hewlett-Packard Co
+ *	David Mosberger-Tang <davidm@hpl.hp.com>
+ *	Stephane Eranian <eranian@hpl.hp.com>
+ *
+ * 01/07/99 S.Eranian modified to pass command line arguments to kernel
+ */
+
+#include "bootloader.h"
+
+#include "fw-emu.h"
+#include "memstr.h"
+#include "ssc.h"
+#include "memstr.h"
+
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long uint64_t;
+
+struct disk_req {
+	unsigned long addr;
+	unsigned len;
+};
+
+struct disk_stat {
+	int fd;
+	unsigned count;
+};
+
+extern void jmp_to_kernel (unsigned long bp, unsigned long e_entry);
+
+void
+cons_write (const char *buf)
+{
+	unsigned long ch;
+
+	while ((ch = *buf++) != '\0') {
+		ssc(ch, 0, 0, 0, SSC_PUTCHAR);
+		if (ch == '\n')
+			ssc('\r', 0, 0, 0, SSC_PUTCHAR);
+	}
+}
+
+#define MAX_ARGS 32
+
+struct pe_coff_header
+{
+	uint16_t machine;
+	uint16_t num_of_sections;
+	uint32_t timestamp;
+	uint32_t ptr_to_symtable;
+	uint32_t num_symbols;
+	uint16_t size_of_opt_header;
+	uint16_t characteristics;
+};
+
+struct pe_optional_header
+{
+	uint16_t magic;
+	uint16_t linker_version;
+	uint32_t code_size;
+	uint32_t data_size;
+	uint32_t bss_size;
+	uint32_t entry_point;
+};
+
+struct pe32_section_table
+{
+	char name[8];
+	uint32_t virtual_size;
+	uint32_t virtual_address;
+	uint32_t raw_data_size;
+	uint32_t raw_data_offset;
+	uint32_t relocations_offset;
+	uint32_t line_numbers_offset;
+	uint16_t num_relocations;
+	uint16_t num_line_numbers;
+	uint32_t characteristics;
+};
+
+struct pe32_fixup_block
+{
+	uint32_t page_rva;
+	uint32_t block_size;
+	uint16_t entries[0];
+};
+
+extern char fake_image_handle;
+
+void
+start_bootloader (void)
+{
+	static char mem[4096];
+	static char buffer[1024];
+	int fd, i;
+	struct disk_req req;
+	struct disk_stat stat;
+	efi_system_table_t *systab;
+	struct pe_coff_header *coff_header;
+	struct pe_optional_header *opt_header;
+	struct pe32_section_table *sec_hdr;
+	char *kpath, *args;
+	long arglen = 0;
+
+	ssc(0, 0, 0, 0, SSC_CONSOLE_INIT);
+
+	/*
+	 * S.Eranian: extract the commandline argument from the simulator
+	 *
+	 * The expected format is as follows:
+         *
+	 *     kernelname args...
+	 *
+	 * Both are optional but you can't have the second one without the first.
+	 */
+	arglen = ssc((long) buffer, 0, 0, 0, SSC_GET_ARGS);
+
+	kpath = "vmlinux";
+	args = buffer;
+	if (arglen > 0) {
+		kpath = buffer;
+		/* Advance args pointer to skip kernel and whitespace after. */
+		while (*args != ' ' && *args != '\0')
+			++args, --arglen;
+		if (*args == ' ')
+			*args++ = '\0', --arglen;
+	}
+
+	if (arglen <= 0) {
+		args = "";
+		arglen = 1;
+	}
+
+	fd = ssc((long) kpath, 1, 0, 0, SSC_OPEN);
+
+	if (fd < 0) {
+		cons_write(kpath);
+		cons_write(": file not found, reboot now\n");
+		for(;;);
+	}
+	stat.fd = fd;
+
+	req.len = sizeof(mem);
+	req.addr = (long) mem;
+	ssc(fd, 1, (long) &req, 0, SSC_READ);
+	ssc((long) &stat, 0, 0, 0, SSC_WAIT_COMPLETION);
+
+	char *msdos_stub = (char *) mem;
+	if (strncmp(msdos_stub, "MZ", 2) != 0) {
+		cons_write("not a PE file\n");
+		return;
+	}
+
+	uint32_t pe_offset = *(uint32_t *) (mem + 0x3c);
+
+	req.len = 4;
+	req.addr = (long) mem;
+	ssc(fd, 1, (long) &req, pe_offset, SSC_READ);
+	ssc((long) &stat, 0, 0, 0, SSC_WAIT_COMPLETION);
+
+	if (strncmp(mem, "PE", 2) != 0) {
+		cons_write("not a PE file\n");
+		return;
+	}
+
+	cons_write("loading ");
+	cons_write(kpath);
+	cons_write("...\n");
+
+	req.len = sizeof(*coff_header);
+	req.addr = (long) mem;
+	ssc(fd, 1, (long) &req, pe_offset + 4, SSC_READ);
+	ssc((long) &stat, 0, 0, 0, SSC_WAIT_COMPLETION);
+
+	coff_header = (void*) mem;
+
+	if (coff_header->machine != 0x200) {
+		cons_write("PE file for wrong machine\n");
+		return;	    
+	}
+
+	uint32_t num_of_sections = coff_header->num_of_sections;
+
+	uint32_t sec_offset0 = pe_offset + 4 + sizeof (*coff_header) + coff_header->size_of_opt_header;
+
+	req.len = sizeof(*opt_header);
+	req.addr = (long) mem;
+	ssc(fd, 1, (long) &req, pe_offset + 4 + sizeof (*coff_header), SSC_READ);
+	ssc((long) &stat, 0, 0, 0, SSC_WAIT_COMPLETION);
+
+	opt_header = (void*) mem;
+
+	uint64_t entry_point = opt_header->entry_point;
+
+	uint64_t image_base = 0x500000, image_size = 0;
+
+	init_memory_map();
+
+	uint64_t sec_end = sec_offset0 + num_of_sections * sizeof(*sec_hdr);
+
+	req.len = sec_end;
+	req.addr = __pa(image_base);
+	ssc(fd, 1, (long) &req, 0, SSC_READ);
+	ssc((long) &stat, 0, 0, 0, SSC_WAIT_COMPLETION);
+	mark_memory(image_base, image_base + sec_end, EFI_LOADER_DATA);
+
+	uint32_t sec_offset = sec_offset0;
+
+	for (i = 0; i < num_of_sections; ++i) {
+		req.len = sizeof(*sec_hdr);
+		req.addr = (long) mem;
+		ssc(fd, 1, (long) &req, sec_offset, SSC_READ);
+		ssc((long) &stat, 0, 0, 0, SSC_WAIT_COMPLETION);
+		if (stat.count != sizeof(*sec_hdr)) {
+			cons_write("failed to read phdr\n");
+			return;
+		}
+		sec_offset += sizeof(*sec_hdr);
+
+		sec_hdr = (void *) mem;
+
+		req.len = sec_hdr->raw_data_size;
+		req.addr = __pa(sec_hdr->virtual_address + image_base);
+		ssc(fd, 1, (long) &req, sec_hdr->raw_data_offset, SSC_READ);
+		ssc((long) &stat, 0, 0, 0, SSC_WAIT_COMPLETION);
+		memset((char *)__pa(sec_hdr->virtual_address + image_base) + sec_hdr->raw_data_size, 0,
+		       sec_hdr->virtual_size - sec_hdr->raw_data_size);
+		/* TODO: use LOADER_DATA for data.  */
+		mark_memory(sec_hdr->virtual_address + image_base, sec_hdr->virtual_address + image_base + sec_hdr->virtual_size, EFI_LOADER_CODE);
+		if (sec_hdr->virtual_address + sec_hdr->virtual_size > image_size)
+		  image_size = sec_hdr->virtual_address + sec_hdr->virtual_size;
+	}
+
+	sec_offset = sec_offset0;
+
+	for (i = 0; i < num_of_sections; ++i) {
+		req.len = sizeof(*sec_hdr);
+		req.addr = (long) mem;
+		ssc(fd, 1, (long) &req, sec_offset, SSC_READ);
+		ssc((long) &stat, 0, 0, 0, SSC_WAIT_COMPLETION);
+		if (stat.count != sizeof(*sec_hdr)) {
+			cons_write("failed to read phdr\n");
+			return;
+		}
+		sec_offset += sizeof(*sec_hdr);
+
+		sec_hdr = (void *) mem;
+
+		if (strncmp (sec_hdr->name, ".reloc", 8) == 0) {
+			uint32_t off = sec_hdr->raw_data_offset;
+			uint32_t end = sec_hdr->raw_data_offset + sec_hdr->raw_data_size;
+			while (off < end) {
+				struct pe32_fixup_block fb;
+				req.len = sizeof (fb);
+				req.addr = (long) mem;
+				ssc(fd, 1, (long) &req, off, SSC_READ);
+				ssc((long) &stat, 0, 0, 0, SSC_WAIT_COMPLETION);
+				off += sizeof(fb);
+
+				fb = *(struct pe32_fixup_block *)mem;
+				for (int i = 0; i < (fb.block_size - sizeof(fb)) / 2; i++) {
+					uint16_t fu;
+					req.len = sizeof (fu);
+					req.addr = (long) mem;
+					ssc(fd, 1, (long) &req, off, SSC_READ);
+					ssc((long) &stat, 0, 0, 0, SSC_WAIT_COMPLETION);
+					off += 2;
+
+					fu = *(uint16_t *)mem;
+
+					void *target = (uint64_t *) (((fu & 0xfff) | fb.page_rva) + image_base);
+					uint16_t type = fu >> 12;
+
+					switch (type) {
+					case 0:
+						break;
+					case 10:
+						*(uint64_t *) target += image_base;
+						break;
+					default:
+						cons_write("Unknown relocation type\n");
+						return;
+					}
+				}
+			}
+		}
+	}
+
+	ssc(fd, 0, 0, 0, SSC_CLOSE);
+
+	cons_write("starting kernel...\n");
+
+	/* fake an I/O base address. */
+	asm volatile ("mov ar0=%0" : : "r"(0xffffc000000ULL) : "memory");
+
+	systab = sys_fw_init(args, arglen, image_base, image_size);
+
+	ssc(0, (long) kpath, 0, 0, SSC_LOAD_SYMBOLS);
+
+	((void (*) (void *, void *))image_base + entry_point) (&fake_image_handle, systab);
+
+	cons_write("kernel returned!\n");
+	ssc(-1, 0, 0, 0, SSC_EXIT);
+}

--- a/ski-efi/bootloader.h
+++ b/ski-efi/bootloader.h
@@ -1,0 +1,16 @@
+#include <ia64/sal.h>
+
+typedef union ia64_va {
+	struct {
+		unsigned long off : 61;		/* intra-region offset */
+		unsigned long reg :  3;		/* region number */
+	} f;
+	unsigned long l;
+	void *p;
+} ia64_va;
+
+/*
+ * I think in firmware code we can directly use identity mapping.
+ * as we did not enable virtual addressing yet.
+ */
+#define __pa(x)		({ia64_va _v; _v.l = (long) (x); _v.f.reg = 0; _v.l;})

--- a/ski-efi/bootloader.lds
+++ b/ski-efi/bootloader.lds
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+OUTPUT_FORMAT("elf64-ia64-little")
+OUTPUT_ARCH(ia64)
+ENTRY(_start)
+SECTIONS
+{
+  /* Read-only sections, merged into text segment: */
+  . = 0x100000;
+
+  _text = .;
+  .text : { *(__ivt_section) *(.text) }
+  _etext = .;
+
+  /* Global data */
+  _data = .;
+  .rodata : { *(.rodata) *(.rodata.*) }
+  .data    : { *(.data) *(.gnu.linkonce.d*) CONSTRUCTORS }
+  __gp = ALIGN (8) + 0x200000;
+  .got           : { *(.got.plt) *(.got) }
+  /* We want the small data sections together, so single-instruction offsets
+     can access them all, and initialized data all before uninitialized, so
+     we can shorten the on-disk segment size.  */
+  .sdata     : { *(.sdata) }
+  _edata  =  .;
+
+  __bss_start = .;
+  .sbss      : { *(.sbss) *(.scommon) }
+  .bss       : { *(.bss) *(COMMON) }
+  . = ALIGN(64 / 8);
+  __bss_stop = .;
+  _end = . ;
+
+  /* Stabs debugging sections.  */
+  .stab 0 : { *(.stab) }
+  .stabstr 0 : { *(.stabstr) }
+  .stab.excl 0 : { *(.stab.excl) }
+  .stab.exclstr 0 : { *(.stab.exclstr) }
+  .stab.index 0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment 0 : { *(.comment) }
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+  /* These must appear regardless of  .  */
+}

--- a/ski-efi/fw-emu.c
+++ b/ski-efi/fw-emu.c
@@ -1,0 +1,567 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * PAL & SAL emulation.
+ *
+ * Copyright (C) 1998-2001 Hewlett-Packard Co
+ *	David Mosberger-Tang <davidm@hpl.hp.com>
+ */
+
+#include "fw-emu.h"
+
+#include "bootloader.h"
+#include "memstr.h"
+#include "ssc.h"
+
+#define MB	(1024*1024UL)
+
+
+char fake_image_handle;
+efi_loaded_image_t *efi_loaded_image_protocol;
+
+static char fw_mem[(  sizeof(efi_system_table_t)
+		    + sizeof(efi_runtime_services_t)
+		    + sizeof(efi_boot_services_t)
+		    + sizeof(efi_loaded_image_t)
+  	            + sizeof(efi_simple_text_output_interface_t)
+		    + sizeof(efi_simple_input_interface_t)
+		    + 1*sizeof(efi_config_table_t)
+		    + sizeof(struct ia64_sal_systab)
+		    + sizeof(struct ia64_sal_desc_entry_point)
+		    + 1024)] __attribute__ ((aligned (8)));
+
+#define SECS_PER_HOUR   (60 * 60)
+#define SECS_PER_DAY    (SECS_PER_HOUR * 24)
+
+/* Compute the `struct tm' representation of *T,
+   offset OFFSET seconds east of UTC,
+   and store year, yday, mon, mday, wday, hour, min, sec into *TP.
+   Return nonzero if successful.  */
+int
+offtime (unsigned long t, efi_time_t *tp)
+{
+	const unsigned short int __mon_yday[2][13] =
+	{
+		/* Normal years.  */
+		{ 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 },
+		/* Leap years.  */
+		{ 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 }
+	};
+	long int days, rem, y;
+	const unsigned short int *ip;
+
+	days = t / SECS_PER_DAY;
+	rem = t % SECS_PER_DAY;
+	while (rem < 0) {
+		rem += SECS_PER_DAY;
+		--days;
+	}
+	while (rem >= SECS_PER_DAY) {
+		rem -= SECS_PER_DAY;
+		++days;
+	}
+	tp->hour = rem / SECS_PER_HOUR;
+	rem %= SECS_PER_HOUR;
+	tp->minute = rem / 60;
+	tp->second = rem % 60;
+	/* January 1, 1970 was a Thursday.  */
+	y = 1970;
+
+#	define DIV(a, b) ((a) / (b) - ((a) % (b) < 0))
+#	define LEAPS_THRU_END_OF(y) (DIV (y, 4) - DIV (y, 100) + DIV (y, 400))
+#	define __isleap(year) \
+	  ((year) % 4 == 0 && ((year) % 100 != 0 || (year) % 400 == 0))
+
+	while (days < 0 || days >= (__isleap (y) ? 366 : 365)) {
+		/* Guess a corrected year, assuming 365 days per year.  */
+		long int yg = y + days / 365 - (days % 365 < 0);
+
+		/* Adjust DAYS and Y to match the guessed year.  */
+		days -= ((yg - y) * 365 + LEAPS_THRU_END_OF (yg - 1)
+			 - LEAPS_THRU_END_OF (y - 1));
+		y = yg;
+	}
+	tp->year = y;
+	ip = __mon_yday[__isleap(y)];
+	for (y = 11; days < (long int) ip[y]; --y)
+		continue;
+	days -= ip[y];
+	tp->month = y + 1;
+	tp->day = days + 1;
+	return 1;
+}
+
+extern void pal_emulator_static (void);
+
+/* Macro to emulate SAL call using legacy IN and OUT calls to CF8, CFC etc.. */
+
+#define BUILD_CMD(addr)		((0x80000000 | (addr)) & ~3)
+
+#define REG_OFFSET(addr)	(0x00000000000000FF & (addr))
+#define DEVICE_FUNCTION(addr)	(0x000000000000FF00 & (addr))
+#define BUS_NUMBER(addr)	(0x0000000000FF0000 & (addr))
+
+static efi_status_t
+fw_efi_get_time (efi_time_t *tm, efi_time_cap_t *tc)
+{
+	struct {
+		int tv_sec;	/* must be 32bits to work */
+		int tv_usec;
+	} tv32bits;
+
+	ssc((unsigned long) &tv32bits, 0, 0, 0, SSC_GET_TOD);
+
+	memset(tm, 0, sizeof(*tm));
+	offtime(tv32bits.tv_sec, tm);
+
+	if (tc)
+		memset(tc, 0, sizeof(*tc));
+	return EFI_SUCCESS;
+}
+
+static void
+efi_reset_system (int reset_type, efi_status_t status, unsigned long data_size, efi_char16_t *data)
+{
+	ssc(status, 0, 0, 0, SSC_EXIT);
+}
+
+void
+cons_write (const char *buf);
+
+static efi_status_t
+efi_output_string (struct efi_simple_text_output_interface *this,
+		   unsigned short *string)
+{
+  char buf[5];
+  for (int i = 0; string[i]; i++) {
+    unsigned int code = string[i];
+    // TODO: surrogates
+    if (code <= 0x7f)
+      ssc(code, 0, 0, 0, SSC_PUTCHAR);
+    else if (code <= 0x07FF)
+      {
+	ssc((code >> 6) | 0xC0, 0, 0, 0, SSC_PUTCHAR);
+	ssc((code & 0x3F) | 0x80, 0, 0, 0, SSC_PUTCHAR);
+      }
+    else
+      {
+	ssc((code >> 12) | 0xE0, 0, 0, 0, SSC_PUTCHAR);
+	ssc(((code >> 6) & 0x3F) | 0x80, 0, 0, 0, SSC_PUTCHAR);
+	ssc((code & 0x3F) | 0x80, 0, 0, 0, SSC_PUTCHAR);
+      }
+  }
+
+  return EFI_SUCCESS;
+}
+
+static efi_status_t
+efi_read_key_stroke(struct efi_simple_input_interface *this,
+		    efi_input_key_t *key)
+{
+  char c = ssc(0, 0, 0, 0, SSC_GETCHAR);
+  if (c)
+    {
+      key->unicode_char = c;
+      key->scan_code = 0;
+      return EFI_SUCCESS;
+    }
+  return EFI_NOT_READY;
+}
+
+
+static efi_status_t
+efi_unimplemented (void)
+{
+  //  cons_write("unsupported\n");
+	return EFI_UNSUPPORTED;
+}
+
+static efi_status_t
+efi_success_stub (void)
+{
+	return EFI_SUCCESS;
+}
+
+static struct sal_ret_values
+sal_emulator (long index, unsigned long in1, unsigned long in2,
+	      unsigned long in3, unsigned long in4, unsigned long in5,
+	      unsigned long in6, unsigned long in7)
+{
+	long r9  = 0;
+	long r10 = 0;
+	long r11 = 0;
+	long status;
+
+	/*
+	 * Don't do a "switch" here since that gives us code that
+	 * isn't self-relocatable.
+	 */
+	status = 0;
+	if (index == SAL_FREQ_BASE) {
+		if (in1 == SAL_FREQ_BASE_PLATFORM)
+			r9 = 200000000;
+		else if (in1 == SAL_FREQ_BASE_INTERVAL_TIMER) {
+			/*
+			 * Is this supposed to be the cr.itc frequency
+			 * or something platform specific?  The SAL
+			 * doc ain't exactly clear on this...
+			 */
+			r9 = 700000000;
+		} else if (in1 == SAL_FREQ_BASE_REALTIME_CLOCK)
+			r9 = 1;
+		else
+			status = -1;
+	} else if (index == SAL_SET_VECTORS) {
+		;
+	} else if (index == SAL_GET_STATE_INFO) {
+		;
+	} else if (index == SAL_GET_STATE_INFO_SIZE) {
+		;
+	} else if (index == SAL_CLEAR_STATE_INFO) {
+		;
+	} else if (index == SAL_MC_RENDEZ) {
+		;
+	} else if (index == SAL_MC_SET_PARAMS) {
+		;
+	} else if (index == SAL_CACHE_FLUSH) {
+		;
+	} else if (index == SAL_CACHE_INIT) {
+		;
+#ifdef CONFIG_PCI
+	} else if (index == SAL_PCI_CONFIG_READ) {
+		/*
+		 * in1 contains the PCI configuration address and in2
+		 * the size of the read.  The value that is read is
+		 * returned via the general register r9.
+		 */
+                outl(BUILD_CMD(in1), 0xCF8);
+                if (in2 == 1)                           /* Reading byte  */
+                        r9 = inb(0xCFC + ((REG_OFFSET(in1) & 3)));
+                else if (in2 == 2)                      /* Reading word  */
+                        r9 = inw(0xCFC + ((REG_OFFSET(in1) & 2)));
+                else                                    /* Reading dword */
+                        r9 = inl(0xCFC);
+                status = PCIBIOS_SUCCESSFUL;
+	} else if (index == SAL_PCI_CONFIG_WRITE) {
+	      	/*
+		 * in1 contains the PCI configuration address, in2 the
+		 * size of the write, and in3 the actual value to be
+		 * written out.
+		 */
+                outl(BUILD_CMD(in1), 0xCF8);
+                if (in2 == 1)                           /* Writing byte  */
+                        outb(in3, 0xCFC + ((REG_OFFSET(in1) & 3)));
+                else if (in2 == 2)                      /* Writing word  */
+                        outw(in3, 0xCFC + ((REG_OFFSET(in1) & 2)));
+                else                                    /* Writing dword */
+                        outl(in3, 0xCFC);
+                status = PCIBIOS_SUCCESSFUL;
+#endif /* CONFIG_PCI */
+	} else if (index == SAL_UPDATE_PAL) {
+		;
+	} else {
+		status = -1;
+	}
+	return ((struct sal_ret_values) {status, r9, r10, r11});
+}
+
+static unsigned char memory_map[MB*2];
+static unsigned long map_key;
+
+void
+mark_memory(unsigned long start, unsigned long end, unsigned char type)
+{
+  unsigned long start_page = ((unsigned long)start) >> 12;
+  unsigned long end_page = ((unsigned long)end + 0xfff) >> 12;
+  unsigned long i;
+  for (i = start_page; i < end_page && i < sizeof(memory_map); i++)
+    memory_map[i] = type;
+  map_key++;
+}
+
+extern unsigned char _start, _end;
+
+void init_memory_map(void)
+{
+  mark_memory(0*MB, 2048*MB, EFI_CONVENTIONAL_MEMORY);
+  mark_memory((long) &_start, (long) &_end, EFI_PAL_CODE);
+  mark_memory(4096*MB, 6144*MB, EFI_CONVENTIONAL_MEMORY);
+}
+
+
+efi_status_t
+efi_allocate_pages(int type, int memory_type, unsigned long pages,
+		   efi_physical_addr_t *memory)
+{
+  switch(type)
+    {
+    case 0: // Any pages
+      *memory = sizeof(memory_map) << 12;
+    case 1: {// max address
+      unsigned long found_pages = 0;
+      for (long i = *memory >> 12; i >= 0; i--)
+	{
+	  if (memory_map[i] == EFI_CONVENTIONAL_MEMORY)
+	    found_pages++;
+	  else
+	    found_pages = 0;
+	  if (found_pages >= pages)
+	    {
+	      *memory = i << 12;
+	      mark_memory(i << 12, (i + pages) << 12, memory_type);
+	      return EFI_SUCCESS;
+	      }
+	}
+      return EFI_OUT_OF_RESOURCES;
+    }
+    case 2: {// Address
+        unsigned long start_page = ((unsigned long)*memory) >> 12;
+	unsigned long end_page = start_page + pages;
+	unsigned long i;
+	if (end_page > sizeof(memory_map))
+	  return EFI_OUT_OF_RESOURCES;
+	for (i = start_page; i < end_page; i++)
+	  if (memory_map[i] != EFI_CONVENTIONAL_MEMORY)
+	    return EFI_OUT_OF_RESOURCES;
+	mark_memory(start_page << 12, end_page << 12, memory_type);
+	return EFI_SUCCESS;
+    }
+    default:
+      cons_write("unsupported allocation type");
+      return EFI_UNSUPPORTED;  
+    }
+}
+
+static unsigned long count_regions(void)
+{
+  unsigned long ret = 0;
+  for (unsigned long i = 0; i < sizeof(memory_map); i++)
+    {
+      if (memory_map[i] && (i == 0 || memory_map[i-1] != memory_map[i]))
+	ret++;
+    }
+  return ret;
+}
+
+efi_status_t
+efi_get_memory_map(unsigned long *memory_map_size, void *memory_map_ptr, unsigned long *map_key_ptr,
+		   unsigned long *descriptor_size, u32 *descriptor_version)
+{
+  efi_memory_desc_t *descs = memory_map_ptr;
+  *descriptor_size = sizeof(efi_memory_desc_t);
+  *descriptor_version = 1;
+  *map_key_ptr = map_key;
+
+  unsigned long num_regions = count_regions();
+  if (num_regions * sizeof(efi_memory_desc_t) > *memory_map_size)
+    {
+      *memory_map_size = num_regions * sizeof(efi_memory_desc_t);
+      return EFI_BUFFER_TOO_SMALL;
+    }
+  *memory_map_size = num_regions * sizeof(efi_memory_desc_t);
+  unsigned long outcnt = 0;
+  for (unsigned long i = 0; i < sizeof(memory_map); i++)
+    {
+      if (memory_map[i] && (i == 0 || memory_map[i-1] != memory_map[i]))
+	{
+	  unsigned long j;
+	  for (j = i; j < sizeof(memory_map); j++)
+	    if (memory_map[j] != memory_map[i])
+	      break;
+	  descs[outcnt].type = memory_map[i];
+	  descs[outcnt].pad = 0;
+	  descs[outcnt].phys_addr = i << 12;
+	  descs[outcnt].virt_addr = i << 12;
+	  descs[outcnt].num_pages = j - i;
+	  descs[outcnt].attribute = EFI_MEMORY_WB;
+	  i = j - 1;
+	  outcnt++;
+	}
+    }
+  return EFI_SUCCESS;
+}
+
+int
+memcmp(void *ai, void *bi, unsigned long sz)
+{
+  char *a = ai;
+  char *b = bi;
+  for (unsigned long i = 0; i < sz; i++)
+    if (a[i] != b[i])
+      {
+	return (unsigned char)a[i] - (unsigned char)b[i];
+      }
+  return 0;
+}
+
+efi_status_t
+efi_open_protocol(efi_handle_t handle,
+		  efi_guid_t *protocol,
+		  void **protocol_interface,
+		  efi_handle_t agent_handle,
+		  efi_handle_t controller_handle,
+		  unsigned int attributes)
+{
+  efi_guid_t loaded_image = EFI_LOADED_IMAGE_GUID;
+  if (memcmp(protocol, &loaded_image, 16) == 0 && attributes == EFI_OPEN_PROTOCOL_GET_PROTOCOL && handle == &fake_image_handle) {
+    *protocol_interface = efi_loaded_image_protocol;
+    return EFI_SUCCESS;
+  }
+  cons_write("Unsupported open_protocol\n");
+  return EFI_UNSUPPORTED;
+}
+
+efi_system_table_t * sys_fw_init (const char *args, int arglen, u64 image_base, u64 image_size)
+{
+	efi_system_table_t *efi_systab;
+	efi_runtime_services_t *efi_runtime;
+	efi_boot_services_t *efi_boottime;
+	efi_simple_text_output_interface_t *efi_conout;
+	efi_simple_input_interface_t *efi_conin;
+	efi_config_table_t *efi_tables;
+	struct ia64_sal_systab *sal_systab;
+	efi_memory_desc_t *efi_memmap, *md;
+	unsigned long *pal_desc, *sal_desc;
+	struct ia64_sal_desc_entry_point *sal_ed;
+	unsigned char checksum = 0;
+	char *cp, *sal_end;
+	int i = 0;
+
+	memset(fw_mem, 0, sizeof(fw_mem));
+
+	pal_desc = (unsigned long *) &pal_emulator_static;
+	sal_desc = (unsigned long *) &sal_emulator;
+
+	cp = fw_mem;
+	efi_systab  = (void *) cp; cp += sizeof(*efi_systab);
+	efi_runtime = (void *) cp; cp += sizeof(*efi_runtime);
+	efi_conout  = (void *) cp; cp += sizeof(*efi_conout);
+	efi_conin  = (void *) cp; cp += sizeof(*efi_conin); 
+	efi_boottime = (void *) cp; cp += sizeof(*efi_boottime);
+	efi_loaded_image_protocol = (void *) cp; cp += sizeof(*efi_loaded_image_protocol);
+	efi_tables  = (void *) cp; cp += sizeof(*efi_tables);
+	sal_systab  = (void *) cp; cp += sizeof(*sal_systab);
+	sal_ed      = (void *) cp; cp += sizeof(*sal_ed);
+	sal_end     = (void *) cp;
+
+	memset(efi_systab, 0, sizeof(*efi_systab));
+	efi_systab->hdr.signature = EFI_SYSTEM_TABLE_SIGNATURE;
+	efi_systab->hdr.revision  = ((1 << 16) | 00);
+	efi_systab->hdr.headersize = sizeof(efi_systab->hdr);
+	efi_systab->fw_vendor = __pa("H\0e\0w\0l\0e\0t\0t\0-\0P\0a\0c\0k\0a\0r\0d\0\0");
+	efi_systab->fw_revision = 1;
+	efi_systab->runtime = (void *) __pa(efi_runtime);
+	efi_systab->boottime = (void *) __pa(efi_boottime);
+	efi_systab->con_in = (void *) __pa(efi_conin);
+	efi_systab->con_out = (void *) __pa(efi_conout);
+	efi_systab->nr_tables = 1;
+	efi_systab->tables = __pa(efi_tables);
+
+	efi_conout->reset = (void *)__pa(&efi_unimplemented);
+	efi_conout->output_string = (void *)__pa(&efi_output_string);
+	efi_conout->test_string = (void *)__pa(&efi_unimplemented);
+	efi_conout->query_mode = (void *)__pa(&efi_unimplemented);
+	efi_conout->set_mode = (void *)__pa(&efi_unimplemented);
+	efi_conout->set_attributes = (void *)__pa(&efi_unimplemented);
+	efi_conout->clear_screen = (void *)__pa(&efi_unimplemented);
+	efi_conout->set_cursor_position = (void *)__pa(&efi_unimplemented);
+	efi_conout->enable_cursor = (void *)__pa(&efi_unimplemented);
+
+	efi_conin->reset = (void *)__pa(&efi_unimplemented);
+	efi_conin->read_key_stroke = (void *)__pa(&efi_read_key_stroke);
+
+	efi_boottime->hdr.signature = EFI_BOOT_SERVICES_SIGNATURE;
+	efi_boottime->hdr.revision = EFI_BOOT_SERVICES_REVISION;
+	efi_boottime->hdr.headersize = sizeof(efi_boottime->hdr);
+
+	efi_boottime->raise_tpl = (void *)__pa(&efi_unimplemented);
+	efi_boottime->restore_tpl = (void *)__pa(&efi_unimplemented);
+	efi_boottime->allocate_pages = (void *)__pa(&efi_allocate_pages);
+	efi_boottime->free_pages = (void *)__pa(&efi_unimplemented);
+	efi_boottime->get_memory_map = (void *)__pa(&efi_get_memory_map);
+	efi_boottime->allocate_pool = (void *)__pa(&efi_unimplemented);
+	efi_boottime->free_pool = (void *)__pa(&efi_unimplemented);
+	efi_boottime->create_event = (void *)__pa(&efi_unimplemented);
+	efi_boottime->set_timer = (void *)__pa(&efi_unimplemented);
+	efi_boottime->wait_for_event = (void *)__pa(&efi_unimplemented);
+	efi_boottime->signal_event = (void *)__pa(&efi_unimplemented);
+	efi_boottime->close_event = (void *)__pa(&efi_unimplemented);
+	efi_boottime->check_event = (void *)__pa(&efi_unimplemented);
+	efi_boottime->install_protocol_interface = (void *)__pa(&efi_unimplemented);
+	efi_boottime->reinstall_protocol_interface = (void *)__pa(&efi_unimplemented);
+	efi_boottime->uninstall_protocol_interface = (void *)__pa(&efi_unimplemented);
+	efi_boottime->handle_protocol = (void *)__pa(&efi_unimplemented);
+	efi_boottime->__reserved = (void *)__pa(&efi_unimplemented);
+	efi_boottime->register_protocol_notify = (void *)__pa(&efi_unimplemented);
+	efi_boottime->locate_handle = (void *)__pa(&efi_unimplemented);
+	efi_boottime->locate_device_path = (void *)__pa(&efi_unimplemented);
+	efi_boottime->install_configuration_table = (void *)__pa(&efi_unimplemented);
+	efi_boottime->load_image = (void *)__pa(&efi_unimplemented);
+	efi_boottime->start_image = (void *)__pa(&efi_unimplemented);
+	efi_boottime->exit = (void *)__pa(&efi_unimplemented);
+	efi_boottime->unload_image = (void *)__pa(&efi_unimplemented);
+	efi_boottime->exit_boot_services = (void *)__pa(&efi_success_stub);
+	efi_boottime->get_next_monotonic_count = (void *)__pa(&efi_unimplemented);
+	efi_boottime->stall = (void *)__pa(&efi_unimplemented);
+	efi_boottime->set_watchdog_timer = (void *)__pa(&efi_unimplemented);
+	efi_boottime->connect_controller = (void *)__pa(&efi_unimplemented);
+	efi_boottime->disconnect_controller = (void *)__pa(&efi_unimplemented);
+	efi_boottime->open_protocol = (void *)__pa(&efi_open_protocol);
+	efi_boottime->close_protocol = (void *)__pa(&efi_unimplemented);
+	efi_boottime->open_protocol_information = (void *)__pa(&efi_unimplemented);
+	efi_boottime->protocols_per_handle = (void *)__pa(&efi_unimplemented);
+	efi_boottime->locate_handle_buffer = (void *)__pa(&efi_unimplemented);
+	efi_boottime->locate_protocol = (void *)__pa(&efi_unimplemented);
+	efi_boottime->install_multiple_protocol_interfaces = (void *)__pa(&efi_unimplemented);
+	efi_boottime->uninstall_multiple_protocol_interfaces = (void *)__pa(&efi_unimplemented);
+	efi_boottime->calculate_crc32 = (void *)__pa(&efi_unimplemented);
+	efi_boottime->copy_mem = (void *)__pa(&efi_unimplemented);
+	efi_boottime->set_mem = (void *)__pa(&efi_unimplemented);
+	efi_boottime->create_event_ex = (void *)__pa(&efi_unimplemented);
+
+	efi_loaded_image_protocol->revision = 0x1000;
+	efi_loaded_image_protocol->image_base = (void *) image_base;
+	efi_loaded_image_protocol->image_size = image_size;
+	efi_loaded_image_protocol->image_code_type = EFI_LOADER_CODE;
+	efi_loaded_image_protocol->image_data_type = EFI_LOADER_DATA;
+	efi_loaded_image_protocol->unload = (void *)__pa(&efi_unimplemented);
+
+	efi_runtime->hdr.signature = EFI_RUNTIME_SERVICES_SIGNATURE;
+	efi_runtime->hdr.revision = EFI_RUNTIME_SERVICES_REVISION;
+	efi_runtime->hdr.headersize = sizeof(efi_runtime->hdr);
+	efi_runtime->get_time = (void *)__pa(&fw_efi_get_time);
+	efi_runtime->set_time = (void *)__pa(&efi_unimplemented);
+	efi_runtime->get_wakeup_time = (void *)__pa(&efi_unimplemented);
+	efi_runtime->set_wakeup_time = (void *)__pa(&efi_unimplemented);
+	efi_runtime->set_virtual_address_map = (void *)__pa(&efi_unimplemented);
+	efi_runtime->get_variable = (void *)__pa(&efi_unimplemented);
+	efi_runtime->get_next_variable = (void *)__pa(&efi_unimplemented);
+	efi_runtime->set_variable = (void *)__pa(&efi_unimplemented);
+	efi_runtime->get_next_high_mono_count = (void *)__pa(&efi_unimplemented);
+	efi_runtime->reset_system = (void *)__pa(&efi_reset_system);
+
+	efi_tables->guid = SAL_SYSTEM_TABLE_GUID;
+	efi_tables->table = __pa(sal_systab);
+
+	/* fill in the SAL system table: */
+	memcpy(sal_systab->signature, "SST_", 4);
+	sal_systab->size = sizeof(*sal_systab);
+	sal_systab->sal_rev_minor = 1;
+	sal_systab->sal_rev_major = 0;
+	sal_systab->entry_count = 1;
+
+	strcpy(sal_systab->oem_id, "Hewlett-Packard");
+	strcpy(sal_systab->product_id, "HP-simulator");
+
+	/* fill in an entry point: */
+	sal_ed->type = SAL_DESC_ENTRY_POINT;
+	sal_ed->pal_proc = __pa(pal_desc[0]);
+	sal_ed->sal_proc = __pa(sal_desc[0]);
+	sal_ed->gp = __pa(sal_desc[1]);
+
+	for (cp = (char *) sal_systab; cp < (char *) sal_end; ++cp)
+		checksum += *cp;
+
+	sal_systab->checksum = -checksum;
+
+	return (efi_system_table_t *) __pa(&fw_mem);
+}

--- a/ski-efi/fw-emu.h
+++ b/ski-efi/fw-emu.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef _SKI_BOOTLOADER_FW_EMU_H_
+#define _SKI_BOOTLOADER_FW_EMU_H_
+
+#include <types.h>
+#include <efi.h>
+
+void init_memory_map(void);
+void mark_memory(unsigned long start, unsigned long end, unsigned char type);
+efi_system_table_t * sys_fw_init (const char *args, int arglen, u64 image_base, u64 image_size);
+
+#endif /* _SKI_BOOTLOADER_FW_EMU_H_ */

--- a/ski-efi/include/efi.h
+++ b/ski-efi/include/efi.h
@@ -1,0 +1,377 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef _LINUX_EFI_H
+#define _LINUX_EFI_H
+
+/*
+ * Extensible Firmware Interface
+ * Based on 'Extensible Firmware Interface Specification' version 0.9, April 30, 1999
+ *
+ * Copyright (C) 1999 VA Linux Systems
+ * Copyright (C) 1999 Walt Drummond <drummond@valinux.com>
+ * Copyright (C) 1999, 2002-2003 Hewlett-Packard Co.
+ *	David Mosberger-Tang <davidm@hpl.hp.com>
+ *	Stephane Eranian <eranian@hpl.hp.com>
+ */
+#include <types.h>
+
+#define BITS_PER_LONG (sizeof (long) * 8)
+
+#define EFI_SUCCESS		0
+#define EFI_UNSUPPORTED		( 3 | (1UL << (BITS_PER_LONG-1)))
+#define EFI_BUFFER_TOO_SMALL	( 5 | (1UL << (BITS_PER_LONG-1)))
+#define EFI_NOT_READY		( 6 | (1UL << (BITS_PER_LONG-1)))
+#define EFI_OUT_OF_RESOURCES	( 9 | (1UL << (BITS_PER_LONG-1)))
+
+typedef unsigned long efi_status_t;
+typedef u8 efi_bool_t;
+typedef u16 efi_char16_t;		/* UNICODE character */
+typedef u64 efi_physical_addr_t;
+typedef void *efi_handle_t;
+
+typedef struct {
+	unsigned char b[16];
+} efi_guid_t;
+
+#define EFI_GUID(a, b, c, d0, d1, d2, d3, d4, d5, d6, d7)			\
+((efi_guid_t)								\
+{{ (a) & 0xff, ((a) >> 8) & 0xff, ((a) >> 16) & 0xff, ((a) >> 24) & 0xff, \
+   (b) & 0xff, ((b) >> 8) & 0xff,					\
+   (c) & 0xff, ((c) >> 8) & 0xff,					\
+   (d0), (d1), (d2), (d3), (d4), (d5), (d6), (d7) }})
+
+/*
+ * Generic EFI table header
+ */
+typedef	struct {
+	u64 signature;
+	u32 revision;
+	u32 headersize;
+	u32 crc32;
+	u32 reserved;
+} efi_table_hdr_t;
+
+/*
+ * Memory map descriptor:
+ */
+
+/* Memory types: */
+#define EFI_RESERVED_TYPE		 0
+#define EFI_LOADER_CODE			 1
+#define EFI_LOADER_DATA			 2
+#define EFI_BOOT_SERVICES_CODE		 3
+#define EFI_BOOT_SERVICES_DATA		 4
+#define EFI_RUNTIME_SERVICES_CODE	 5
+#define EFI_RUNTIME_SERVICES_DATA	 6
+#define EFI_CONVENTIONAL_MEMORY		 7
+#define EFI_UNUSABLE_MEMORY		 8
+#define EFI_ACPI_RECLAIM_MEMORY		 9
+#define EFI_ACPI_MEMORY_NVS		10
+#define EFI_MEMORY_MAPPED_IO		11
+#define EFI_MEMORY_MAPPED_IO_PORT_SPACE	12
+#define EFI_PAL_CODE			13
+#define EFI_PERSISTENT_MEMORY		14
+#define EFI_MAX_MEMORY_TYPE		15
+
+#define EFI_OPEN_PROTOCOL_GET_PROTOCOL		0x00000002
+
+/* Attribute values: */
+#define EFI_MEMORY_UC		((u64)0x0000000000000001ULL)	/* uncached */
+#define EFI_MEMORY_WC		((u64)0x0000000000000002ULL)	/* write-coalescing */
+#define EFI_MEMORY_WT		((u64)0x0000000000000004ULL)	/* write-through */
+#define EFI_MEMORY_WB		((u64)0x0000000000000008ULL)	/* write-back */
+#define EFI_MEMORY_UCE		((u64)0x0000000000000010ULL)	/* uncached, exported */
+#define EFI_MEMORY_WP		((u64)0x0000000000001000ULL)	/* write-protect */
+#define EFI_MEMORY_RP		((u64)0x0000000000002000ULL)	/* read-protect */
+#define EFI_MEMORY_XP		((u64)0x0000000000004000ULL)	/* execute-protect */
+#define EFI_MEMORY_NV		((u64)0x0000000000008000ULL)	/* non-volatile */
+#define EFI_MEMORY_MORE_RELIABLE \
+				((u64)0x0000000000010000ULL)	/* higher reliability */
+#define EFI_MEMORY_RO		((u64)0x0000000000020000ULL)	/* read-only */
+#define EFI_MEMORY_RUNTIME	((u64)0x8000000000000000ULL)	/* range requires runtime mapping */
+#define EFI_MEMORY_DESCRIPTOR_VERSION	1
+
+#define EFI_PAGE_SHIFT		12
+#define EFI_PAGE_SIZE		(1UL << EFI_PAGE_SHIFT)
+#define EFI_PAGES_MAX		(U64_MAX >> EFI_PAGE_SHIFT)
+
+typedef struct {
+	u32 type;
+	u32 pad;
+	u64 phys_addr;
+	u64 virt_addr;
+	u64 num_pages;
+	u64 attribute;
+} efi_memory_desc_t;
+
+typedef struct {
+	efi_guid_t guid;
+	u32 headersize;
+	u32 flags;
+	u32 imagesize;
+} efi_capsule_header_t;
+
+/*
+ * Types and defines for Time Services
+ */
+#define EFI_TIME_ADJUST_DAYLIGHT 0x1
+#define EFI_TIME_IN_DAYLIGHT     0x2
+#define EFI_UNSPECIFIED_TIMEZONE 0x07ff
+
+typedef struct {
+	u16 year;
+	u8 month;
+	u8 day;
+	u8 hour;
+	u8 minute;
+	u8 second;
+	u8 pad1;
+	u32 nanosecond;
+	s16 timezone;
+	u8 daylight;
+	u8 pad2;
+} efi_time_t;
+
+typedef struct {
+	u32 resolution;
+	u32 accuracy;
+	u8 sets_to_zero;
+} efi_time_cap_t;
+
+typedef struct efi_simple_text_output_mode efi_simple_text_output_mode_t;
+
+typedef struct efi_simple_text_output_interface
+{
+  efi_status_t
+  (*reset) (struct efi_simple_text_output_interface *this,
+	    int extended_verification);
+
+  efi_status_t
+  (*output_string) (struct efi_simple_text_output_interface *this,
+		    efi_char16_t *string);
+
+  efi_status_t
+  (*test_string) (struct efi_simple_text_output_interface *this,
+		  efi_char16_t *string);
+
+  efi_status_t
+  (*query_mode) (struct efi_simple_text_output_interface *this,
+		 unsigned long mode_number,
+		 unsigned long *columns,
+		 unsigned long *rows);
+
+  efi_status_t
+  (*set_mode) (struct efi_simple_text_output_interface *this,
+	       unsigned long mode_number);
+
+  efi_status_t
+  (*set_attributes) (struct efi_simple_text_output_interface *this,
+		     unsigned long attribute);
+
+  efi_status_t
+  (*clear_screen) (struct efi_simple_text_output_interface *this);
+
+  efi_status_t
+  (*set_cursor_position) (struct efi_simple_text_output_interface *this,
+			  unsigned long column,
+			  unsigned long row);
+
+  efi_status_t
+  (*enable_cursor) (struct efi_simple_text_output_interface *this,
+		    int visible);
+
+  efi_simple_text_output_mode_t *mode;
+} efi_simple_text_output_interface_t;
+
+typedef struct efi_input_key
+{
+  unsigned short scan_code;
+  efi_char16_t unicode_char;
+} efi_input_key_t;
+
+
+typedef struct efi_simple_input_interface
+{
+  efi_status_t
+  (*reset) (struct efi_simple_input_interface *this,
+	    int extended_verification);
+
+  efi_status_t
+  (*read_key_stroke) (struct efi_simple_input_interface *this,
+		      efi_input_key_t *key);
+
+  unsigned long wait_for_key;
+} efi_simple_input_interface_t;
+
+/*
+ * EFI Boot Services table
+ */
+typedef struct {
+	efi_table_hdr_t hdr;
+	void *raise_tpl;
+	void *restore_tpl;
+	efi_status_t (*allocate_pages)(int, int, unsigned long,
+				       efi_physical_addr_t *);
+	efi_status_t (*free_pages)(efi_physical_addr_t, unsigned long);
+	efi_status_t (*get_memory_map)(unsigned long *, void *, unsigned long *,
+				       unsigned long *, u32 *);
+	efi_status_t (*allocate_pool)(int, unsigned long, void **);
+	efi_status_t (*free_pool)(void *);
+	void *create_event;
+	void *set_timer;
+	void *wait_for_event;
+	void *signal_event;
+	void *close_event;
+	void *check_event;
+	void *install_protocol_interface;
+	void *reinstall_protocol_interface;
+	void *uninstall_protocol_interface;
+	efi_status_t (*handle_protocol)(efi_handle_t, efi_guid_t *, void **);
+	void *__reserved;
+	void *register_protocol_notify;
+	efi_status_t (*locate_handle)(int, efi_guid_t *, void *,
+				      unsigned long *, efi_handle_t *);
+	void *locate_device_path;
+	efi_status_t (*install_configuration_table)(efi_guid_t *, void *);
+	void *load_image;
+	void *start_image;
+	void *exit;
+	void *unload_image;
+	efi_status_t (*exit_boot_services)(efi_handle_t, unsigned long);
+	void *get_next_monotonic_count;
+	void *stall;
+	void *set_watchdog_timer;
+	void *connect_controller;
+	void *disconnect_controller;
+	efi_status_t (*open_protocol) (efi_handle_t handle,
+				       efi_guid_t *protocol,
+				       void **protocol_interface,
+				       efi_handle_t agent_handle,
+				       efi_handle_t controller_handle,
+				       unsigned int attributes);
+	void *close_protocol;
+	void *open_protocol_information;
+	void *protocols_per_handle;
+	void *locate_handle_buffer;
+	efi_status_t (*locate_protocol)(efi_guid_t *, void *, void **);
+	void *install_multiple_protocol_interfaces;
+	void *uninstall_multiple_protocol_interfaces;
+	void *calculate_crc32;
+	void *copy_mem;
+	void *set_mem;
+	void *create_event_ex;
+} efi_boot_services_t;
+
+#define EFI_BOOT_SERVICES_SIGNATURE ((u64)0x56524553544f4f42ULL)
+#define EFI_BOOT_SERVICES_REVISION  0x00010000
+
+/*
+ * EFI Runtime Services table
+ */
+#define EFI_RUNTIME_SERVICES_SIGNATURE ((u64)0x5652453544e5552ULL)
+#define EFI_RUNTIME_SERVICES_REVISION  0x00010000
+
+typedef efi_status_t efi_get_time_t (efi_time_t *tm, efi_time_cap_t *tc);
+typedef efi_status_t efi_set_time_t (efi_time_t *tm);
+typedef efi_status_t efi_get_wakeup_time_t (efi_bool_t *enabled, efi_bool_t *pending,
+					    efi_time_t *tm);
+typedef efi_status_t efi_set_wakeup_time_t (efi_bool_t enabled, efi_time_t *tm);
+typedef efi_status_t efi_get_variable_t (efi_char16_t *name, efi_guid_t *vendor, u32 *attr,
+					 unsigned long *data_size, void *data);
+typedef efi_status_t efi_get_next_variable_t (unsigned long *name_size, efi_char16_t *name,
+					      efi_guid_t *vendor);
+typedef efi_status_t efi_set_variable_t (efi_char16_t *name, efi_guid_t *vendor, 
+					 u32 attr, unsigned long data_size,
+					 void *data);
+typedef efi_status_t efi_get_next_high_mono_count_t (u32 *count);
+typedef void efi_reset_system_t (int reset_type, efi_status_t status,
+				 unsigned long data_size, efi_char16_t *data);
+typedef efi_status_t efi_set_virtual_address_map_t (unsigned long memory_map_size,
+						unsigned long descriptor_size,
+						u32 descriptor_version,
+						efi_memory_desc_t *virtual_map);
+typedef efi_status_t efi_query_variable_info_t(u32 attr,
+					       u64 *storage_space,
+					       u64 *remaining_space,
+					       u64 *max_variable_size);
+typedef efi_status_t efi_update_capsule_t(efi_capsule_header_t **capsules,
+					  unsigned long count,
+					  unsigned long sg_list);
+typedef efi_status_t efi_query_capsule_caps_t(efi_capsule_header_t **capsules,
+					      unsigned long count,
+					      u64 *max_size,
+					      int *reset_type);
+typedef efi_status_t efi_query_variable_store_t(u32 attributes,
+						unsigned long size,
+						int nonblocking);
+
+typedef struct {
+	efi_table_hdr_t			hdr;
+	efi_get_time_t			*get_time;
+	efi_set_time_t			*set_time;
+	efi_get_wakeup_time_t		*get_wakeup_time;
+	efi_set_wakeup_time_t		*set_wakeup_time;
+	efi_set_virtual_address_map_t	*set_virtual_address_map;
+	void				*convert_pointer;
+	efi_get_variable_t		*get_variable;
+	efi_get_next_variable_t		*get_next_variable;
+	efi_set_variable_t		*set_variable;
+	efi_get_next_high_mono_count_t	*get_next_high_mono_count;
+	efi_reset_system_t		*reset_system;
+	efi_update_capsule_t		*update_capsule;
+	efi_query_capsule_caps_t	*query_capsule_caps;
+	efi_query_variable_info_t	*query_variable_info;
+} efi_runtime_services_t;
+
+#define SAL_SYSTEM_TABLE_GUID			EFI_GUID(0xeb9d2d32, 0x2d88, 0x11d3,  0x9a, 0x16, 0x00, 0x90, 0x27, 0x3f, 0xc1, 0x4d)
+
+typedef struct {
+	efi_guid_t guid;
+	unsigned long table;
+} efi_config_table_t;
+
+#define EFI_SYSTEM_TABLE_SIGNATURE ((u64)0x5453595320494249ULL) /* "IBI SYST" */
+
+typedef struct {
+	efi_table_hdr_t hdr;
+	unsigned long fw_vendor;	/* physical addr of CHAR16 vendor string */
+	u32 fw_revision;
+	unsigned long con_in_handle;
+	efi_simple_input_interface_t *con_in;
+	unsigned long con_out_handle;
+	efi_simple_text_output_interface_t *con_out;
+	unsigned long stderr_handle;
+	unsigned long stderr;
+	efi_runtime_services_t *runtime;
+	efi_boot_services_t *boottime;
+	unsigned long nr_tables;
+	unsigned long tables;
+} efi_system_table_t;
+
+#define EFI_LOADED_IMAGE_GUID	\
+  { 0xa1, 0x31, 0x1b, 0x5b, 0x62, 0x95, 0xd2, 0x11,  \
+      0x8e, 0x3f, 0x00, 0xa0, 0xc9, 0x69, 0x72, 0x3b \
+  }
+
+struct efi_loaded_image
+{
+  u32 revision;
+  efi_handle_t parent_handle;
+  efi_system_table_t *system_table;
+
+  efi_handle_t device_handle;
+  void *file_path;
+  void *reserved;
+
+  u32 load_options_size;
+  void *load_options;
+
+  void *image_base;
+  u64 image_size;
+  u32 image_code_type;
+  u32 image_data_type;
+
+  efi_status_t (*unload) (efi_handle_t image_handle);
+};
+typedef struct efi_loaded_image efi_loaded_image_t;
+
+#endif /* _LINUX_EFI_H */

--- a/ski-efi/include/ia64/pal.h
+++ b/ski-efi/include/ia64/pal.h
@@ -1,0 +1,12 @@
+#ifndef _INCLUDE_PAL_H_
+#define _INCLUDE_PAL_H_
+
+#define PAL_CACHE_FLUSH		1
+#define PAL_MEM_ATTRIB		5
+#define PAL_PTCE_INFO		6
+#define PAL_VM_SUMMARY		8
+#define PAL_FREQ_RATIOS		14
+#define PAL_PERF_MON_INFO	15
+#define PAL_RSE_INFO		19
+
+#endif /* _INCLUDE_PAL_H_ */

--- a/ski-efi/include/ia64/sal.h
+++ b/ski-efi/include/ia64/sal.h
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef _ASM_IA64_SAL_H
+#define _ASM_IA64_SAL_H
+
+/*
+ * System Abstraction Layer definitions.
+ *
+ * This is based on version 2.5 of the manual "IA-64 System
+ * Abstraction Layer".
+ *
+ * Copyright (C) 2001 Intel
+ * Copyright (C) 2002 Jenna Hall <jenna.s.hall@intel.com>
+ * Copyright (C) 2001 Fred Lewis <frederick.v.lewis@intel.com>
+ * Copyright (C) 1998, 1999, 2001, 2003 Hewlett-Packard Co
+ *	David Mosberger-Tang <davidm@hpl.hp.com>
+ * Copyright (C) 1999 Srinivasa Prasad Thirumalachar <sprasad@sprasad.engr.sgi.com>
+ *
+ * 02/01/04 J. Hall Updated Error Record Structures to conform to July 2001
+ *		    revision of the SAL spec.
+ * 01/01/03 fvlewis Updated Error Record Structures to conform with Nov. 2000
+ *                  revision of the SAL spec.
+ * 99/09/29 davidm	Updated for SAL 2.6.
+ * 00/03/29 cfleck      Updated SAL Error Logging info for processor (SAL 2.6)
+ *                      (plus examples of platform error info structures from smariset @ Intel)
+ */
+
+#include <efi.h>
+
+#define SAL_SET_VECTORS			0x01000000
+#define SAL_GET_STATE_INFO		0x01000001
+#define SAL_GET_STATE_INFO_SIZE		0x01000002
+#define SAL_CLEAR_STATE_INFO		0x01000003
+#define SAL_MC_RENDEZ			0x01000004
+#define SAL_MC_SET_PARAMS		0x01000005
+
+#define SAL_CACHE_FLUSH			0x01000008
+#define SAL_CACHE_INIT			0x01000009
+#define SAL_FREQ_BASE			0x01000012
+
+#define SAL_UPDATE_PAL			0x01000020
+
+enum {
+	SAL_FREQ_BASE_PLATFORM = 0,
+	SAL_FREQ_BASE_INTERVAL_TIMER = 1,
+	SAL_FREQ_BASE_REALTIME_CLOCK = 2
+};
+
+/*
+ * The SAL system table is followed by a variable number of variable
+ * length descriptors.  The structure of these descriptors follows
+ * below.
+ * The defininition follows SAL specs from July 2000
+ */
+struct ia64_sal_systab {
+	u8 signature[4];	/* should be "SST_" */
+	u32 size;		/* size of this table in bytes */
+	u8 sal_rev_minor;
+	u8 sal_rev_major;
+	u16 entry_count;	/* # of entries in variable portion */
+	u8 checksum;
+	u8 reserved1[7];
+	u8 sal_a_rev_minor;
+	u8 sal_a_rev_major;
+	u8 sal_b_rev_minor;
+	u8 sal_b_rev_major;
+	/* oem_id & product_id: terminating NUL is missing if string is exactly 32 bytes long. */
+	u8 oem_id[32];
+	u8 product_id[32];	/* ASCII product id  */
+	u8 reserved2[8];
+};
+
+enum sal_systab_entry_type {
+	SAL_DESC_ENTRY_POINT = 0,
+};
+
+typedef struct ia64_sal_desc_entry_point {
+	u8 type;
+	u8 reserved1[7];
+	u64 pal_proc;
+	u64 sal_proc;
+	u64 gp;
+	u8 reserved2[16];
+} ia64_sal_desc_entry_point_t;
+
+struct sal_ret_values {
+	long r8; long r9; long r10; long r11;
+};
+
+#endif /* _ASM_IA64_SAL_H */

--- a/ski-efi/include/types.h
+++ b/ski-efi/include/types.h
@@ -1,0 +1,13 @@
+#ifndef _INCLUDE_TYPES_H_
+#define _INCLUDE_TYPES_H_
+
+typedef   signed char      s8;
+typedef unsigned char      u8;
+typedef   signed short     s16;
+typedef unsigned short     u16;
+typedef   signed int       s32;
+typedef unsigned int       u32;
+typedef   signed long long s64;
+typedef unsigned long long u64;
+
+#endif /* _INCLUDE_TYPES_H_ */

--- a/ski-efi/memstr.c
+++ b/ski-efi/memstr.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * String function implementation for firmwar.
+ * Normally thouse would live in <string.h>
+ */
+
+#include "memstr.h"
+
+void * memcpy(void * dst, const void * src, unsigned long len) {
+	char * cd = dst;
+	const char * cs = src;
+
+	while (len--) {
+		*cd++ = *cs++;
+	}
+	return cd;
+}
+
+void *memset (void * dst, int c, unsigned long len) {
+	char * cd = dst;
+	while (len--) {
+		*cd++ = c;
+	}
+	return cd;
+}
+
+char *strcpy(char *dst, const char *src) {
+	char * r = dst;
+	while (*src) {
+		*dst++ = *src++;
+	}
+	return r;
+}
+
+int strncmp (const char * s1, const char * s2, unsigned long len) {
+	while (len--) {
+		char c1 = *s1++;
+		char c2 = *s2++;
+
+		if (c1 < c2) return -1;
+		if (c1 > c2) return  1;
+
+		if (c1 == '\0') break;
+	}
+	return 0;
+}

--- a/ski-efi/memstr.h
+++ b/ski-efi/memstr.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef _SKI_BOOTLOADER_MEMSTR_H_
+#define _SKI_BOOTLOADER_MEMSTR_H_
+
+void * memcpy(void * dst, const void * src, unsigned long len);
+void *memset (void * dst, int c, unsigned long len);
+char *strcpy(char *dst, const char *src);
+int strncmp(const char * s1, const char * s2, unsigned long len);
+
+#endif /* _SKI_BOOTLOADER_MEMSTR_H_ */

--- a/ski-efi/ssc.h
+++ b/ski-efi/ssc.h
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (C) 1998-2003 Hewlett-Packard Co
+ *	David Mosberger-Tang <davidm@hpl.hp.com>
+ *	Stephane Eranian <eranian@hpl.hp.com>
+ */
+#ifndef ssc_h
+#define ssc_h
+
+/* Simulator system calls: */
+
+#define SSC_CONSOLE_INIT		20
+#define SSC_GETCHAR			21
+#define SSC_PUTCHAR			31
+#define SSC_OPEN			50
+#define SSC_CLOSE			51
+#define SSC_READ			52
+#define SSC_WRITE			53
+#define SSC_GET_COMPLETION		54
+#define SSC_WAIT_COMPLETION		55
+#define SSC_CONNECT_INTERRUPT		58
+#define SSC_GENERATE_INTERRUPT		59
+#define SSC_SET_PERIODIC_INTERRUPT	60
+#define SSC_GET_RTC			65
+#define SSC_EXIT			66
+#define SSC_LOAD_SYMBOLS		69
+#define SSC_GET_TOD			74
+#define SSC_GET_ARGS			75
+#define SSC_GET_INITRAMFS		77
+
+/*
+ * Simulator system call.
+ */
+extern long ssc (long arg0, long arg1, long arg2, long arg3, int nr);
+
+#endif /* ssc_h */


### PR DESCRIPTION
This is far from fully functional EFI but this stub allows running ia64 GRUB and in turn it was able to run modified sim kernel. So it is already somewhat useful. Based on ski-bootloader and EFI specification