### PR TITLE
src/tlb.c: restore original order of operation for atype assignment

### DIFF
--- a/src/tlb.c
+++ b/src/tlb.c
@@ -691,7 +691,7 @@ static int keyCheck(Accesstype atype, unsigned key)
 static BOOL accessRights(unsigned ar, unsigned pl, unsigned cpl,
 			 Accesstype atype)
 {
-    Accesstypemask atypem = atype & READ_ACCESS | WRITE_ACCESS;
+    Accesstypemask atypem = atype & (READ_ACCESS | WRITE_ACCESS);
 
     switch (ar) {
 	case 0:


### PR DESCRIPTION
After 3279e9defb3b trying to boot a Linux kernel in (b)ski's system mode hang early.

As `&` takes precedence over `|` the assigned value of `atypem` is different after 3279e9defb3b than the assigned value of `atype` was before that commit.

****

Fixes #30 